### PR TITLE
Add advanced FoundationModels playground examples

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/AgentAssistant.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/AgentAssistant.swift
@@ -1,0 +1,16 @@
+//
+//  AgentAssistant.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let agent = Agent(role: "assistant")
+    let session = LanguageModelSession(instructions: "You help manage tasks.", agent: agent)
+    let options = GenerationOptions(temperature: 0.5, maximumResponseTokens: 1000)
+    let response = try await session.respond(to: "Organize my todo list", options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ArticleSummary.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ArticleSummary.swift
@@ -1,0 +1,19 @@
+//
+//  ArticleSummary.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You summarize articles in bullet points."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.2, maximumResponseTokens: 1000)
+    let prompts = [
+        "Summarize the key points from an article about renewable energy in five bullet points."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/AutocompleteAssistant.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/AutocompleteAssistant.swift
@@ -1,0 +1,14 @@
+//
+//  AutocompleteAssistant.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Suggest text completions.")
+    let response = try await session.respond(to: "The meaning of life is")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ChainedPrompts.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ChainedPrompts.swift
@@ -1,0 +1,16 @@
+//
+//  ChainedPrompts.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Answer step by step.")
+    let options = GenerationOptions(temperature: 0.2, maximumResponseTokens: 1000)
+    let first = try await session.respond(to: "Generate a headline", options: options)
+    let second = try await session.respond(to: "Write a short article based on \(first)", options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/CharacterChat.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CharacterChat.swift
@@ -1,0 +1,14 @@
+//
+//  CharacterChat.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Role-play as a medieval knight.")
+    let response = try await session.respond(to: "Greet the queen")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/CodeCompletion.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CodeCompletion.swift
@@ -1,0 +1,19 @@
+//
+//  CodeCompletion.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You generate Swift code."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.1, maximumResponseTokens: 1000)
+    let prompts = [
+        "Write a Swift function that calculates the factorial of a number."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/CodeRefactor.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CodeRefactor.swift
@@ -1,0 +1,15 @@
+//
+//  CodeRefactor.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Refactor code for clarity.")
+    let code = "for i in 0..<10{print(i)}"
+    let refactored = try await session.respond(to: code)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/CodeSummary.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CodeSummary.swift
@@ -1,0 +1,19 @@
+//
+//  CodeSummary.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You summarize code."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.2, maximumResponseTokens: 1000)
+    let prompts = [
+        "Summarize what the following code does: `for i in 0..<5 { print(i) }`"
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/CustomGuide.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CustomGuide.swift
@@ -1,0 +1,15 @@
+//
+//  CustomGuide.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let guide = Guide("Respond in pirate style")
+    let session = LanguageModelSession(instructions: "Use the guide for style.")
+    let response = try await session.respond(to: "Where is the treasure?", guide: guide)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DailyMotivation.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DailyMotivation.swift
@@ -1,0 +1,19 @@
+//
+//  DailyMotivation.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You provide motivational quotes."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.7, maximumResponseTokens: 1000)
+    let prompts = [
+        "Give me a short motivational quote to start the day."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DataExtractor.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DataExtractor.swift
@@ -1,0 +1,15 @@
+//
+//  DataExtractor.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Extract names from text as a list.")
+    let text = "Alice and Bob went to the market with Charlie."
+    let response = try await session.respond(to: text, guide: Guide("Return only names"))
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DebuggingInstructions.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DebuggingInstructions.swift
@@ -1,0 +1,19 @@
+//
+//  DebuggingInstructions.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You provide debugging instructions."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.2, maximumResponseTokens: 1000)
+    let prompts = [
+        "Explain how to troubleshoot a crashed SwiftUI app."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DocumentQA.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DocumentQA.swift
@@ -1,0 +1,15 @@
+//
+//  DocumentQA.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let document = "Foundation models can be adapted to many tasks."
+    let session = LanguageModelSession(instructions: "Answer questions about the document.")
+    let answer = try await session.respond(to: "What can foundation models do?", context: document)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/EmailComposition.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/EmailComposition.swift
@@ -1,0 +1,19 @@
+//
+//  EmailComposition.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You write polite emails."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.3, maximumResponseTokens: 1000)
+    let prompts = [
+        "Compose a short email thanking a colleague for their help on a project."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ExplainConcept.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ExplainConcept.swift
@@ -1,0 +1,19 @@
+//
+//  ExplainConcept.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You explain technical concepts."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.3, maximumResponseTokens: 1000)
+    let prompts = [
+        "Explain the difference between concurrency and parallelism."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/FrenchTranslation.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/FrenchTranslation.swift
@@ -1,0 +1,19 @@
+//
+//  FrenchTranslation.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You translate to French."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.0, maximumResponseTokens: 1000)
+    let prompts = [
+        "Translate this sentence to French: 'The quick brown fox jumps over the lazy dog.'"
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/GenerableStruct.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/GenerableStruct.swift
@@ -1,0 +1,18 @@
+//
+//  GenerableStruct.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct Quote: Generable {
+    let text: String
+}
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Provide an inspirational quote in JSON.")
+    let quote: Quote = try await session.generate(from: "Give me a quote")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/GuidedPrompt.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/GuidedPrompt.swift
@@ -1,0 +1,15 @@
+//
+//  GuidedPrompt.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let guide = Guide("Summarize input in one line")
+    let session = LanguageModelSession(instructions: "Use the guide to answer.")
+    let response = try await session.respond(to: "Explain foundation models", guide: guide)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/Haiku.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/Haiku.swift
@@ -1,0 +1,19 @@
+//
+//  Haiku.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You write haikus."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.7, maximumResponseTokens: 1000)
+    let prompts = [
+        "Compose a haiku about the changing seasons."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/JSONGenerator.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/JSONGenerator.swift
@@ -1,0 +1,19 @@
+//
+//  JSONGenerator.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You output JSON format."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.3, maximumResponseTokens: 1000)
+    let prompts = [
+        "Generate a JSON object with keys name and age for a fictional character."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/KnowledgeBaseLookup.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/KnowledgeBaseLookup.swift
@@ -1,0 +1,14 @@
+//
+//  KnowledgeBaseLookup.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Search a knowledge base for answers.")
+    let answer = try await session.respond(to: "Who developed Swift?", knowledgeBase: "AppleHistory")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MarketingTagline.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MarketingTagline.swift
@@ -1,0 +1,19 @@
+//
+//  MarketingTagline.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You craft marketing taglines."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.6, maximumResponseTokens: 1000)
+    let prompts = [
+        "Create a catchy tagline for an eco-friendly water bottle."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MathSolver.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MathSolver.swift
@@ -1,0 +1,20 @@
+//
+//  MathSolver.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let calculator = Tool("Calculator") { parameters in
+        if let nums = parameters["numbers"] as? [Double] {
+            return .string(String(nums.reduce(0, +)))
+        }
+        return .string("0")
+    }
+    let session = LanguageModelSession(instructions: "Solve math problems using the calculator.", tools: [calculator])
+    let answer = try await session.respond(to: "What is 40 + 2?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ModelPrewarm.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ModelPrewarm.swift
@@ -1,0 +1,15 @@
+//
+//  ModelPrewarm.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    try await LanguageModelSession.prewarm(.init())
+    let session = LanguageModelSession(instructions: "Model has been prewarmed.")
+    let response = try await session.respond(to: "Is the model ready?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MultiLingualTranslator.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MultiLingualTranslator.swift
@@ -1,0 +1,15 @@
+//
+//  MultiLingualTranslator.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Translate between multiple languages.")
+    let text = "Hello, how are you?"
+    let response = try await session.respond(to: text, guide: Guide("Translate to Spanish"))
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MultiModelSession.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MultiModelSession.swift
@@ -1,0 +1,16 @@
+//
+//  MultiModelSession.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(model: .init(named: "ModelA"))
+    let altSession = LanguageModelSession(model: .init(named: "ModelB"))
+    let first = try await session.respond(to: "Explain photosynthesis")
+    let second = try await altSession.respond(to: "Summarize in one sentence: \(first)")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MultiTurnAgent.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MultiTurnAgent.swift
@@ -1,0 +1,16 @@
+//
+//  MultiTurnAgent.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let agent = Agent(role: "planner")
+    let session = LanguageModelSession(instructions: "Plan tasks over multiple turns.", agent: agent)
+    _ = try await session.respond(to: "Plan a trip to Rome")
+    let details = try await session.respond(to: "Add museum visits")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/NaturePoem.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/NaturePoem.swift
@@ -1,0 +1,19 @@
+//
+//  NaturePoem.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You craft poems."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.8, maximumResponseTokens: 1000)
+    let prompts = [
+        "Write a short poem about nature."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/NovelOutline.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/NovelOutline.swift
@@ -1,0 +1,19 @@
+//
+//  NovelOutline.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You outline novels."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.5, maximumResponseTokens: 1000)
+    let prompts = [
+        "Provide a brief outline for a science fiction novel set on Mars."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/RecipeMaker.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/RecipeMaker.swift
@@ -1,0 +1,19 @@
+//
+//  RecipeMaker.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You create recipes."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.5, maximumResponseTokens: 1000)
+    let prompts = [
+        "Provide a simple recipe for chocolate chip cookies."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/RiddleMaker.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/RiddleMaker.swift
@@ -1,0 +1,19 @@
+//
+//  RiddleMaker.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You craft riddles."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.7, maximumResponseTokens: 1000)
+    let prompts = [
+        "Write a short riddle about the moon."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/SQLQueryAssistant.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SQLQueryAssistant.swift
@@ -1,0 +1,14 @@
+//
+//  SQLQueryAssistant.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Generate SQL queries from natural language.")
+    let query = try await session.respond(to: "Show me all rows from users table")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/SentimentAnalyzer.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SentimentAnalyzer.swift
@@ -1,0 +1,15 @@
+//
+//  SentimentAnalyzer.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Analyze sentiment as positive or negative.")
+    let text = "I absolutely love the new product!"
+    let sentiment = try await session.respond(to: text)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ShakespeareConversation.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ShakespeareConversation.swift
@@ -1,0 +1,19 @@
+//
+//  ShakespeareConversation.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You speak like Shakespeare."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.8, maximumResponseTokens: 1000)
+    let prompts = [
+        "Describe the morning sunrise in Shakespearean style."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ShortStory.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ShortStory.swift
@@ -1,0 +1,19 @@
+//
+//  ShortStory.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You tell short stories."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.6, maximumResponseTokens: 1000)
+    let prompts = [
+        "Write a short story about a robot that learns to paint."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/SpeechTranscriber.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SpeechTranscriber.swift
@@ -1,0 +1,14 @@
+//
+//  SpeechTranscriber.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let audioData = Data()
+    let transcript = try await LanguageModelSession.transcribe(audioData)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/StreamingTokens.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/StreamingTokens.swift
@@ -1,0 +1,17 @@
+//
+//  StreamingTokens.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Stream your answer.")
+    let responseStream = try await session.streamResponse(to: "Give me a poem")
+    for try await token in responseStream {
+        print(token)
+    }
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/Summarize.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/Summarize.swift
@@ -1,0 +1,19 @@
+//
+//  Summarize.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You are a summarization assistant."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.2, maximumResponseTokens: 1000)
+    let prompts = [
+        "Summarize the following text in one paragraph: \"Foundation models are large-scale machine learning models trained on broad data that can be adapted to a wide range of tasks.\""
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/SynonymFinder.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SynonymFinder.swift
@@ -1,0 +1,19 @@
+//
+//  SynonymFinder.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You find synonyms for words."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.0, maximumResponseTokens: 1000)
+    let prompts = [
+        "Provide three synonyms for the word 'happy'."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/TestCaseGenerator.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/TestCaseGenerator.swift
@@ -1,0 +1,19 @@
+//
+//  TestCaseGenerator.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You generate unit test cases."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.3, maximumResponseTokens: 1000)
+    let prompts = [
+        "Write XCTest unit tests for a function that reverses a string."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ToolUsage.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ToolUsage.swift
@@ -1,0 +1,22 @@
+//
+//  ToolUsage.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let calculator = Tool("Calculator") { parameters in
+        if let nums = parameters["numbers"] as? [Double] {
+            return .string(String(nums.reduce(0, +)))
+        }
+        return .string("0")
+    }
+
+    let session = LanguageModelSession(instructions: "You can add numbers using the calculator tool.", tools: [calculator])
+    let options = GenerationOptions(temperature: 0.0, maximumResponseTokens: 1000)
+    let response = try await session.respond(to: "Add 2 and 3", options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ToolWithParams.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ToolWithParams.swift
@@ -1,0 +1,20 @@
+//
+//  ToolWithParams.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let weatherTool = Tool("Weather") { params in
+        if let city = params["city"] as? String {
+            return .string("It is sunny in \(city)")
+        }
+        return .string("Unknown")
+    }
+    let session = LanguageModelSession(instructions: "Use tools to provide weather.", tools: [weatherTool])
+    let forecast = try await session.respond(to: "What's the weather in Paris?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/TranscriptReview.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/TranscriptReview.swift
@@ -1,0 +1,17 @@
+//
+//  TranscriptReview.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Track the transcript of our conversation.")
+    let options = GenerationOptions(temperature: 0.3, maximumResponseTokens: 1000)
+    _ = try await session.respond(to: "Hello", options: options)
+    _ = try await session.respond(to: "How are you?", options: options)
+    let transcript = session.transcript
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/TranscriptSummarizer.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/TranscriptSummarizer.swift
@@ -1,0 +1,15 @@
+//
+//  TranscriptSummarizer.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(instructions: "Summarize our transcript at the end.")
+    let _ = try await session.respond(to: "Explain relativity in two lines")
+    let summary = try await session.respond(to: "Summarize the conversation")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/Translate.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/Translate.swift
@@ -1,0 +1,19 @@
+//
+//  Translate.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You are a translation assistant."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.0, maximumResponseTokens: 1000)
+    let prompts = [
+        "Translate the following Spanish text to English: Hola, ¿cómo estás?"
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/TrendingTopics.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/TrendingTopics.swift
@@ -1,0 +1,19 @@
+//
+//  TrendingTopics.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You list current trending topics."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.6, maximumResponseTokens: 1000)
+    let prompts = [
+        "What are some trending technology topics this week?"
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/UnitConverter.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/UnitConverter.swift
@@ -1,0 +1,20 @@
+//
+//  UnitConverter.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let conversionTool = Tool("Converter") { params in
+        if let meters = params["meters"] as? Double {
+            return .string(String(meters * 3.28084))
+        }
+        return .string("0")
+    }
+    let session = LanguageModelSession(instructions: "Use the converter tool for units.", tools: [conversionTool])
+    let feet = try await session.respond(to: "Convert 2 meters to feet")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/VegetarianMenu.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/VegetarianMenu.swift
@@ -1,0 +1,19 @@
+//
+//  VegetarianMenu.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You suggest vegetarian meal options."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.5, maximumResponseTokens: 1000)
+    let prompts = [
+        "Suggest a three-course vegetarian dinner menu."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/WeatherReport.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/WeatherReport.swift
@@ -1,0 +1,19 @@
+//
+//  WeatherReport.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You create weather reports."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.5, maximumResponseTokens: 1000)
+    let prompts = [
+        "Generate a short weather update for a sunny day in San Francisco."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/WorkoutPlan.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/WorkoutPlan.swift
@@ -1,0 +1,19 @@
+//
+//  WorkoutPlan.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by IVAN CAMPOS on 6/11/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You create workout plans."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.4, maximumResponseTokens: 1000)
+    let prompts = [
+        "Create a simple 30-minute full-body workout routine for beginners."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}


### PR DESCRIPTION
## Summary
- add 25 new advanced playground examples using FoundationModels

## Testing
- `swift --version`
- `swiftc Foundation-Models-Playgrounds/Playgrounds/Basic.swift -o /tmp/basic.out` *(fails: no such module 'FoundationModels')*

------
https://chatgpt.com/codex/tasks/task_e_6849d933b6ac83208f52b80086cbdc91