### PR TITLE
Add visionOS Foundation model playgrounds

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/BasicChat.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/BasicChat.swift
@@ -1,0 +1,16 @@
+//
+//  BasicChat.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = try await SystemLanguageModel.default.session()
+    let prompt = Prompt("Hello! Can you tell me a fun fact about Vision Pro?")
+    let response = try await session.respond(to: prompt)
+    print("AI says: \(response.content)")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ChatInstructions.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ChatInstructions.swift
@@ -1,0 +1,17 @@
+//
+//  ChatInstructions.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = try await SystemLanguageModel.default.session()
+    let prompt = Prompt("What are the top 3 highlights of WWDC 2025?")
+    let instructions = "You are a tech news assistant. Answer concisely in one paragraph."
+    let response = try await session.respond(to: prompt, instructions: instructions)
+    print(response.content)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ConstrainedCharacterProfile.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ConstrainedCharacterProfile.swift
@@ -1,0 +1,26 @@
+//
+//  ConstrainedCharacterProfile.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable
+struct CharacterProfile {
+    @Guide(description: "Character name (first and last)")
+    let name: String
+    @Guide(.range(1...10), description: "Level between 1 and 10")
+    let level: Int
+    @Guide(.count(3), description: "Exactly 3 special abilities")
+    let abilities: [String]
+}
+
+#Playground {
+    let session = try await SystemLanguageModel.default.session()
+    let prompt = Prompt("Create a new fantasy RPG character with a unique skill set.")
+    let character = try await session.respond(to: prompt, generating: CharacterProfile.self)
+    print("Name: \(character.name)\nLevel: \(character.level)\nAbilities: \(character.abilities.joined(separator: ", "))")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ConversationMemory.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ConversationMemory.swift
@@ -1,0 +1,21 @@
+//
+//  ConversationMemory.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = try await SystemLanguageModel.default.session()
+    try await session.respond(to: Prompt("My favorite color is blue."))
+    let question1 = Prompt("What is my favorite color?")
+    let answer1 = try await session.respond(to: question1)
+    print("Q: \(question1.content)\nA: \(answer1.content)")
+
+    let question2 = Prompt("Could you suggest a car that matches it?")
+    let answer2 = try await session.respond(to: question2)
+    print("Q: \(question2.content)\nA: \(answer2.content)")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ErrorHandling.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ErrorHandling.swift
@@ -1,0 +1,24 @@
+//
+//  ErrorHandling.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    do {
+        let session = try await SystemLanguageModel.default.session()
+        let prompt = Prompt("Tell me the population of Mars.")
+        let answer = try await session.respond(to: prompt)
+        print("Answer: \(answer.content)")
+    } catch FoundationModelsError.modelUnavailable {
+        print("The AI model is not available on this device or is not enabled.")
+    } catch FoundationModelsError.contentDisallowed {
+        print("The query or response was flagged as disallowed content.")
+    } catch {
+        print("An unexpected error occurred: \(error.localizedDescription)")
+    }
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MathTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MathTool.swift
@@ -1,0 +1,38 @@
+//
+//  MathTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct MathTool: Tool {
+    let name = "calculator"
+    let description = "Performs basic arithmetic operations and returns the result."
+    func call(_ input: MathQuery) async throws -> Double {
+        switch input.operation {
+        case "+":
+            return input.a + input.b
+        case "-":
+            return input.a - input.b
+        case "*":
+            return input.a * input.b
+        case "/":
+            return input.b != 0 ? input.a / input.b : Double.nan
+        default:
+            throw MathError.invalidOperation
+        }
+    }
+}
+
+@Generable struct MathQuery {
+    let a: Double
+    let b: Double
+    let operation: String
+}
+
+enum MathError: Error {
+    case invalidOperation
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ModelAvailability.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ModelAvailability.swift
@@ -1,0 +1,23 @@
+//
+//  ModelAvailability.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let model = SystemLanguageModel.default
+    switch model.state {
+    case .available:
+        print("Foundation model is ready to use.")
+    case .downloading:
+        print("\u231B The model is downloading... please wait.")
+    case .notSupported:
+        print("Foundation model not supported on this device.")
+    @unknown default:
+        print("\u2642 Unknown state.")
+    }
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/StreamingPoem.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/StreamingPoem.swift
@@ -1,0 +1,18 @@
+//
+//  StreamingPoem.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = try await SystemLanguageModel.default.session()
+    let prompt = Prompt("Write a short poem about technology and nature.")
+    let stream = session.streamResponse(to: prompt)
+    for try await partial in stream {
+        print(partial, terminator: "")
+    }
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/StructuredBookRecommendation.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/StructuredBookRecommendation.swift
@@ -1,0 +1,26 @@
+//
+//  StructuredBookRecommendation.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable
+struct BookRecommendation {
+    @Guide(description: "The title of the book")
+    let title: String
+    @Guide(description: "The author's name")
+    let author: String
+    @Guide(description: "Genre of the book")
+    let genre: String
+}
+
+#Playground {
+    let session = try await SystemLanguageModel.default.session()
+    let prompt = Prompt("Suggest a science fiction book for someone who liked Dune.")
+    let book: BookRecommendation = try await session.respond(to: prompt, generating: BookRecommendation.self)
+    print("**Book Title:** \(book.title)\n**Author:** \(book.author)\n**Genre:** \(book.genre)")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ToolCalling.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ToolCalling.swift
@@ -1,0 +1,18 @@
+//
+//  ToolCalling.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let tools: [Tool] = [MathTool()]
+    let config = LanguageModel.Configuration(tools: tools)
+    let session = try await SystemLanguageModel.default.session(configuration: config)
+    let prompt = Prompt("What is 12 * 9 - 5?")
+    let answer = try await session.respond(to: prompt)
+    print("The answer: \(answer.content)")
+}


### PR DESCRIPTION
## Summary
- add playground example for checking the model state
- demonstrate simple chat and system instructions
- use `@Generable` for structured and constrained outputs
- show defining a custom tool and tool calling
- illustrate streaming responses, conversation memory, and error handling

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849e4c5d864832086d917a1d6410876