### PR TITLE
Add tool calling playground examples

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/CityWeatherTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CityWeatherTool.swift
@@ -1,0 +1,41 @@
+//
+//  CityWeatherTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct WeatherTool: Tool {
+    let name = "getWeather"
+    let description = "Retrieve the latest weather information for a city"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "The city to get weather information for")
+        var city: String
+    }
+
+    struct Forecast: Encodable {
+        var city: String
+        var temperature: Int
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let forecast = GeneratedContent(properties: [
+            "city": arguments.city,
+            "temperature": 72,
+        ])
+        return ToolOutput(forecast)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [WeatherTool()],
+        instructions: "Provide temperature updates using the weather tool."
+    )
+    let response = try await session.respond(to: "Is it warmer in London or Paris?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ContactLookupTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ContactLookupTool.swift
@@ -1,0 +1,36 @@
+//
+//  ContactLookupTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct ContactSearchTool: Tool {
+    let name = "lookupContact"
+    let description = "Find a contact's phone number"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Name of the contact to search")
+        var name: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "name": arguments.name,
+            "phone": "555-1234"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [ContactSearchTool()],
+        instructions: "Look up contacts when asked"
+    )
+    let response = try await session.respond(to: "What's Jane Doe's phone number?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/GameDifficultyTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/GameDifficultyTool.swift
@@ -1,0 +1,33 @@
+//
+//  GameDifficultyTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct GameDifficultyTool: Tool {
+    let name = "setGameDifficulty"
+    let description = "Adjusts the game difficulty level"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "The level to set", .range(1...10))
+        var level: Int
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        print("Game difficulty set to \(arguments.level)")
+        return ToolOutput("Difficulty set to \(arguments.level)")
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [GameDifficultyTool()],
+        instructions: "Adjust the difficulty when requested"
+    )
+    let response = try await session.respond(to: "Please set difficulty to 7")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/HealthStepsTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/HealthStepsTool.swift
@@ -1,0 +1,31 @@
+//
+//  HealthStepsTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct StepCountTool: Tool {
+    let name = "getStepCount"
+    let description = "Retrieve today's step count"
+
+    @Generable
+    struct Arguments {}
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let steps = 4500
+        let output = GeneratedContent(properties: ["steps": steps])
+        return ToolOutput(output)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [StepCountTool()],
+        instructions: "Report health steps when asked"
+    )
+    let response = try await session.respond(to: "How many steps did I walk today?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/RecipeFinderTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/RecipeFinderTool.swift
@@ -1,0 +1,38 @@
+//
+//  RecipeFinderTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct RecipeTool: Tool {
+    let name = "searchRecipes"
+    let description = "Searches a local database for bread recipes"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "The type of bread to search for")
+        var searchTerm: String
+        @Guide(description: "The number of recipes to get", .range(1...3))
+        var limit: Int
+    }
+
+    struct Recipe {
+        var name: String
+        var description: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let recipes: [Recipe] = []
+        let formatted = recipes.map { "Recipe for '\($0.name)': \($0.description)" }
+        return ToolOutput(GeneratedContent(properties: ["recipes": formatted]))
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(tools: [RecipeTool()])
+    let response = try await session.respond(to: "Find two sourdough recipes")
+}


### PR DESCRIPTION
## Summary
- add `CityWeatherTool` sample to fetch weather data
- add `RecipeFinderTool` playground for recipe lookups
- add `GameDifficultyTool` to demonstrate adjusting a game level
- add `HealthStepsTool` for retrieving step counts
- add `ContactLookupTool` to look up contact phone numbers

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6849ed86fca48320aec3be050587cda3