### PR TITLE
Add guided generation playground examples

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/CatProfileGenerator.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CatProfileGenerator.swift
@@ -1,0 +1,26 @@
+//
+//  CatProfileGenerator.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Basic profile information about a cat")
+struct CatProfile {
+    var name: String
+
+    @Guide(description: "The age of the cat", .range(0...20))
+    var age: Int
+
+    @Guide(description: "A one sentence profile about the cat's personality")
+    var profile: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Generate a cute rescue cat")
+    let cat = try await session.respond(to: prompt, generating: CatProfile.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DynamicMenu.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DynamicMenu.swift
@@ -1,0 +1,41 @@
+//
+//  DynamicMenu.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let menuSchema = DynamicGenerationSchema(
+        name: "Menu",
+        properties: [
+            DynamicGenerationSchema.Property(
+                name: "dailySoup",
+                schema: DynamicGenerationSchema(
+                    name: "dailySoup",
+                    anyOf: ["Tomato", "Chicken Noodle", "Clam Chowder"]
+                )
+            ),
+            DynamicGenerationSchema.Property(
+                name: "special",
+                schema: DynamicGenerationSchema(
+                    name: "special",
+                    anyOf: ["Burger", "Pasta", "Salad"]
+                )
+            )
+        ]
+    )
+
+    let schema = try GenerationSchema(root: menuSchema, dependencies: [])
+
+    let session = LanguageModelSession()
+    let response = try await session.respond(
+        to: "What are today's specials?",
+        schema: schema
+    )
+
+    let soup: String = try response.value(String.self, forProperty: "dailySoup")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/NestedGenerable.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/NestedGenerable.swift
@@ -1,0 +1,27 @@
+//
+//  NestedGenerable.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Basic profile about a pet")
+struct Pet {
+    var name: String
+    var kind: String
+}
+
+@Generable(description: "Information about a pet owner")
+struct PetOwner {
+    var ownerName: String
+    var pet: Pet
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Describe a pet owner and their cat")
+    let owner = try await session.respond(to: prompt, generating: PetOwner.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/NumericConversion.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/NumericConversion.swift
@@ -1,0 +1,15 @@
+//
+//  NumericConversion.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("How many tablespoons are in a cup?")
+    let tablespoons = try await session.respond(to: prompt, generating: Float.self)
+}


### PR DESCRIPTION
## Summary
- add NumericConversion playground for generating `Float`
- add CatProfileGenerator to demo custom `Generable` type
- add NestedGenerable example with nested `Generable` types
- add DynamicMenu example showing runtime `DynamicGenerationSchema`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849eff9d8388320ae0ac1fb949ac3c0