### PR TITLE
Add new guided generation playgrounds

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/DailyQuote.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DailyQuote.swift
@@ -1,0 +1,21 @@
+//
+//  DailyQuote.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Inspirational quote of the day")
+struct Quote {
+    var text: String
+    var author: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Share an inspirational quote")
+    let quote = try await session.respond(to: prompt, generating: Quote.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/GardenPlanner.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/GardenPlanner.swift
@@ -1,0 +1,24 @@
+//
+//  GardenPlanner.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Information about a garden plant")
+struct Plant {
+    var name: String
+    @Guide(description: "Flower color options", .values(["red", "yellow", "blue", "white"]))
+    var color: String
+    @Guide(description: "Watering frequency in days", .range(1...14))
+    var wateringInterval: Int
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Suggest a flowering plant for a sunny balcony")
+    let plant = try await session.respond(to: prompt, generating: Plant.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/LanguageFlashCard.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/LanguageFlashCard.swift
@@ -1,0 +1,23 @@
+//
+//  LanguageFlashCard.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Simple language learning flash card")
+struct FlashCard {
+    var word: String
+    var translation: String
+    @Guide(description: "Example sentence using the word")
+    var example: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Create a flash card for the Spanish word 'correr'")
+    let card = try await session.respond(to: prompt, generating: FlashCard.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MovieNightRecommendation.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MovieNightRecommendation.swift
@@ -1,0 +1,23 @@
+//
+//  MovieNightRecommendation.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Recommendation for a movie night")
+struct MovieNight {
+    var movieTitle: String
+    var reason: String
+    @Guide(description: "Suggested rating out of 10", .range(1...10))
+    var rating: Int
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Recommend a comedy for movie night")
+    let recommendation = try await session.respond(to: prompt, generating: MovieNight.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MusicAlbum.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MusicAlbum.swift
@@ -1,0 +1,25 @@
+//
+//  MusicAlbum.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Information about a music album")
+struct MusicAlbum {
+    var title: String
+    var artist: String
+    @Guide(description: "Number of tracks on the album", .range(1...20))
+    var trackCount: Int
+    @Guide(description: "List of track titles", .count(1...20))
+    var tracks: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Describe a popular rock album with at least 5 tracks")
+    let album = try await session.respond(to: prompt, generating: MusicAlbum.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/NewsSummary.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/NewsSummary.swift
@@ -1,0 +1,23 @@
+//
+//  NewsSummary.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Brief news summary")
+struct NewsArticle {
+    var title: String
+    var summary: String
+    @Guide(description: "Important keywords", .count(3))
+    var keywords: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Summarize today's top technology news")
+    let article = try await session.respond(to: prompt, generating: NewsArticle.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ResumeGenerator.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ResumeGenerator.swift
@@ -1,0 +1,23 @@
+//
+//  ResumeGenerator.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Basic resume layout")
+struct Resume {
+    var name: String
+    var role: String
+    @Guide(description: "List of 3 accomplishments", .count(3))
+    var highlights: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Generate a resume for a senior iOS developer")
+    let resume = try await session.respond(to: prompt, generating: Resume.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/SuperheroProfile.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SuperheroProfile.swift
@@ -1,0 +1,23 @@
+//
+//  SuperheroProfile.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Profile of a fictional superhero")
+struct SuperheroProfile {
+    var heroName: String
+    var alias: String
+    @Guide(description: "List of super powers", .count(1...5))
+    var powers: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Create a new superhero with at least two powers")
+    let hero = try await session.respond(to: prompt, generating: SuperheroProfile.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/TravelItinerary.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/TravelItinerary.swift
@@ -1,0 +1,24 @@
+//
+//  TravelItinerary.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Simple travel plan for a city")
+struct TravelItinerary {
+    var city: String
+    @Guide(description: "Number of days of the trip", .range(1...14))
+    var days: Int
+    @Guide(description: "Highlights to visit", .count(1...10))
+    var highlights: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Plan a 3 day trip to Tokyo with must-see spots")
+    let itinerary = try await session.respond(to: prompt, generating: TravelItinerary.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/WorkoutSchedule.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/WorkoutSchedule.swift
@@ -1,0 +1,22 @@
+//
+//  WorkoutSchedule.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Weekly workout plan")
+struct WorkoutSchedule {
+    @Guide(description: "Day of the week", .values(["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"]))
+    var day: String
+    var exercises: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Create a weekend workout schedule with two exercises each day")
+    let schedule = try await session.respond(to: prompt, generating: [WorkoutSchedule].self)
+}


### PR DESCRIPTION
## Summary
- add MusicAlbum, TravelItinerary, WorkoutSchedule, LanguageFlashCard, ResumeGenerator
- add SuperheroProfile, GardenPlanner, MovieNightRecommendation, NewsSummary, DailyQuote examples

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6849fbd4a6088320b88bda6fd5fdb91f