### PR TITLE
Add tool calling examples

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/BreadDatabaseTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/BreadDatabaseTool.swift
@@ -1,0 +1,39 @@
+//
+//  BreadDatabaseTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct BreadDatabaseTool: Tool {
+    let name = "searchBreadDatabase"
+    let description = "Searches a local database for bread recipes."
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "The type of bread to search for")
+        var searchTerm: String
+        @Guide(description: "The number of recipes to get", .range(1...6))
+        var limit: Int
+    }
+
+    struct Recipe {
+        var name: String
+        var description: String
+        var link: URL
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        var recipes: [Recipe] = []
+        let formatted = recipes.map { "Recipe for '\($0.name)': \($0.description) Link: \($0.link)" }
+        return ToolOutput(GeneratedContent(properties: ["recipes": formatted]))
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(tools: [BreadDatabaseTool()])
+    let response = try await session.respond(to: "Find two rye bread recipes")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/CalendarEventTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CalendarEventTool.swift
@@ -1,0 +1,36 @@
+//
+//  CalendarEventTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct CalendarEventTool: Tool {
+    let name = "addCalendarEvent"
+    let description = "Adds an event to the user's calendar"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Title of the event")
+        var title: String
+        @Guide(description: "Event date in ISO8601 format")
+        var date: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        return ToolOutput("Event '\(arguments.title)' added for \(arguments.date)")
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [CalendarEventTool()],
+        instructions: "Schedule events when requested"
+    )
+    let response = try await session.respond(
+        to: "Add lunch with Alex on 2026-07-12T12:00:00Z"
+    )
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DarkModeTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DarkModeTool.swift
@@ -1,0 +1,32 @@
+//
+//  DarkModeTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct DarkModeTool: Tool {
+    let name = "toggleDarkMode"
+    let description = "Turn dark mode on or off"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "True to enable dark mode")
+        var enabled: Bool
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        return ToolOutput("Dark mode set to \(arguments.enabled)")
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [DarkModeTool()],
+        instructions: "Use the dark mode tool when asked"
+    )
+    let response = try await session.respond(to: "Please enable dark mode")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DocumentSearchTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DocumentSearchTool.swift
@@ -1,0 +1,33 @@
+//
+//  DocumentSearchTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct DocumentSearchTool: Tool {
+    let name = "searchDocuments"
+    let description = "Find documents matching a query"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Search term to look for")
+        var query: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let results = ["Document related to \(arguments.query)"]
+        return ToolOutput(GeneratedContent(properties: ["results": results]))
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [DocumentSearchTool()],
+        instructions: "Search the documents tool for references"
+    )
+    let response = try await session.respond(to: "Find documentation on matrix multiplication")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MusicPlaylistTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MusicPlaylistTool.swift
@@ -1,0 +1,36 @@
+//
+//  MusicPlaylistTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct MusicPlaylistTool: Tool {
+    let name = "addSongToPlaylist"
+    let description = "Adds a song to a playlist"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "The song title")
+        var title: String
+        @Guide(description: "The playlist name")
+        var playlist: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        return ToolOutput("Added \(arguments.title) to \(arguments.playlist)")
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [MusicPlaylistTool()],
+        instructions: "Manage songs when asked"
+    )
+    let response = try await session.respond(
+        to: "Add 'Imagine' to my favorites playlist"
+    )
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/NewsHeadlineTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/NewsHeadlineTool.swift
@@ -1,0 +1,30 @@
+//
+//  NewsHeadlineTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct NewsHeadlineTool: Tool {
+    let name = "fetchTopHeadlines"
+    let description = "Get the latest news headlines"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "The topic to search for")
+        var topic: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let headlines = ["Example headline about \(arguments.topic)"]
+        return ToolOutput(GeneratedContent(properties: ["headlines": headlines]))
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(tools: [NewsHeadlineTool()])
+    let response = try await session.respond(to: "What's happening in technology?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/SleepDataTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SleepDataTool.swift
@@ -1,0 +1,31 @@
+//
+//  SleepDataTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct SleepDataTool: Tool {
+    let name = "getSleepData"
+    let description = "Retrieve last night's sleep duration"
+
+    @Generable
+    struct Arguments {}
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let hours = 7
+        let output = GeneratedContent(properties: ["hours": hours])
+        return ToolOutput(output)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [SleepDataTool()],
+        instructions: "Report sleep data when asked"
+    )
+    let response = try await session.respond(to: "How long did I sleep last night?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/StockPriceTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/StockPriceTool.swift
@@ -1,0 +1,37 @@
+//
+//  StockPriceTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct StockPriceTool: Tool {
+    let name = "getStockPrice"
+    let description = "Fetch the latest stock price for a ticker"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Ticker symbol to look up")
+        var symbol: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let price = 100.0
+        let info = GeneratedContent(properties: [
+            "symbol": arguments.symbol,
+            "price": price
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [StockPriceTool()],
+        instructions: "Use the stock tool for finance questions"
+    )
+    let response = try await session.respond(to: "What is the price of AAPL?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/TriviaScoreTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/TriviaScoreTool.swift
@@ -1,0 +1,32 @@
+//
+//  TriviaScoreTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct TriviaScoreTool: Tool {
+    let name = "updateScore"
+    let description = "Updates the trivia game score"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Current score to set")
+        var score: Int
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        return ToolOutput("Score updated to \(arguments.score)")
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [TriviaScoreTool()],
+        instructions: "Use the score tool for trivia games"
+    )
+    let response = try await session.respond(to: "Set my trivia score to 5")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/WeatherTool.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/WeatherTool.swift
@@ -1,0 +1,42 @@
+//
+//  WeatherTool.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/12/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct WeatherTool: Tool {
+    let name = "getWeather"
+    let description = "Retrieve the latest weather information for a city"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "The city to get weather information for")
+        var city: String
+    }
+
+    struct Forecast: Encodable {
+        var city: String
+        var temperature: Int
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let temperature = 70
+        let forecast = GeneratedContent(properties: [
+            "city": arguments.city,
+            "temperature": temperature
+        ])
+        return ToolOutput(forecast)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [WeatherTool()],
+        instructions: "Help with weather comparisons"
+    )
+    let response = try await session.respond(to: "Is it warmer in Miami or Seattle?")
+}


### PR DESCRIPTION
## Summary
- add 10 new tool-calling playground examples for custom tools

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849ff4a9c148320a04106fa4c4a1c05