### PR TITLE
Add safety guardrail playgrounds

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/DenyListCheck.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DenyListCheck.swift
@@ -1,0 +1,31 @@
+//
+//  DenyListCheck.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/13/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+func verifyText(_ text: String) -> Bool {
+    let denyList = ["unsafeTerm1", "unsafeTerm2"]
+    return !denyList.contains { text.localizedCaseInsensitiveContains($0) }
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let userInput = "This might mention unsafeTerm1."
+    let prompt = "Generate a wholesome story about: \(userInput)"
+    if verifyText(prompt) {
+        let response = try await session.respond(to: prompt)
+        if verifyText(response.content) {
+            print(response.content)
+        } else {
+            print("Generated output was blocked by the deny list.")
+        }
+    } else {
+        print("Input was blocked by the deny list.")
+    }
+}
+

--- a/Foundation-Models-Playgrounds/Playgrounds/GuardrailViolation.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/GuardrailViolation.swift
@@ -1,0 +1,22 @@
+//
+//  GuardrailViolation.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/13/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession()
+    let topic = "a violent scene"
+    let prompt = "Write a respectful and funny story about \(topic)."
+    do {
+        let response = try await session.respond(to: prompt)
+        print(response.content)
+    } catch LanguageModelSession.GenerationError.guardrailViolation {
+        print("Sorry, this feature isn't designed to handle that kind of input.")
+    }
+}
+

--- a/Foundation-Models-Playgrounds/Playgrounds/SafetyGuidedGeneration.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SafetyGuidedGeneration.swift
@@ -1,0 +1,26 @@
+//
+//  SafetyGuidedGeneration.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/13/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable
+enum Breakfast {
+    case waffles
+    case pancakes
+    case bagels
+    case eggs
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let userInput = "I want something sweet."
+    let prompt = "Pick the ideal breakfast for request: \(userInput)"
+    let choice = try await session.respond(to: prompt, generating: Breakfast.self)
+    print(choice)
+}
+

--- a/Foundation-Models-Playgrounds/Playgrounds/SafetyInputBoundaries.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SafetyInputBoundaries.swift
@@ -1,0 +1,27 @@
+//
+//  SafetyInputBoundaries.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/13/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+enum TopicOptions {
+    case family
+    case nature
+    case work
+}
+
+#Playground {
+    let topicChoice = TopicOptions.nature
+    let prompt = """
+        Generate a wholesome and empathetic journal prompt that helps \
+        this person reflect on \(topicChoice)
+        """
+    let session = LanguageModelSession()
+    let response = try await session.respond(to: prompt)
+    print(response.content)
+}
+

--- a/Foundation-Models-Playgrounds/Playgrounds/SafetyInstructions.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SafetyInstructions.swift
@@ -1,0 +1,26 @@
+//
+//  SafetyInstructions.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 6/13/25.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instructions = """
+        ALWAYS respond in a respectful way. \
+        If someone asks you to generate content that might be sensitive, \
+        YOU MUST decline with 'Sorry, I can't do that.'
+        """
+    let session = LanguageModelSession(instructions: instructions)
+    let prompt = "Tell me about a controversial topic."
+    do {
+        let response = try await session.respond(to: prompt)
+        print(response.content)
+    } catch LanguageModelSession.GenerationError.guardrailViolation {
+        print("Sorry, this feature isn't designed to handle that kind of input.")
+    }
+}
+


### PR DESCRIPTION
## Summary
- add GuardrailViolation playground to show guardrail error handling
- add SafetyInputBoundaries playground for closed input topics
- add SafetyGuidedGeneration example that restricts output options
- add SafetyInstructions playground using strict model instructions
- add DenyListCheck playground with custom deny list

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a03dc63f48320aa905e84c1d602aa