### PR TITLE
Use transcript throughout conversations

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/FilmProduction.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/FilmProduction.swift
@@ -1,0 +1,40 @@
+//
+//  FilmProduction.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instructions = """
+    A film crew is preparing for production. The team includes:
+    - Director
+    - Producer
+    - Cinematographer
+    - Scriptwriter
+    - Sound Engineer
+    Use the role prefix when speaking.
+    """
+
+    let session = LanguageModelSession(instructions: instructions)
+
+    try await session.respond(to: "Director: Our shooting schedule starts next month.")
+    var transcript = session.transcript
+
+    try await session.respond(to: "Producer: Based on the plan so far (\(transcript)), I'll coordinate the logistics and budget allocations.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Cinematographer: Considering previous notes (\(transcript)), I'm planning the lighting setups for key scenes.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Scriptwriter: With our ongoing discussion (\(transcript)), the final draft should be delivered tomorrow.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Sound Engineer: After reviewing the transcript (\(transcript)), I'll organize location audio tests next week.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Director: Great work so far (\(transcript)). Let's keep communication open throughout production.")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/FinancialStrategy.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/FinancialStrategy.swift
@@ -1,0 +1,40 @@
+//
+//  FinancialStrategy.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instructions = """
+    A finance committee is planning investment strategy. The participants are:
+    - Investment Banker
+    - Risk Analyst
+    - Portfolio Manager
+    - Economist
+    - CFO
+    Begin each message with the speaker's role.
+    """
+
+    let session = LanguageModelSession(instructions: instructions)
+
+    try await session.respond(to: "Investment Banker: We should diversify our holdings this quarter.")
+    var transcript = session.transcript
+
+    try await session.respond(to: "Risk Analyst: Considering previous remarks (\(transcript)), I'll assess exposure to interest rate fluctuations.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Portfolio Manager: Using the information so far (\(transcript)), let's rebalance toward energy and tech sectors.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Economist: In light of our discussion (\(transcript)), market indicators suggest stable growth ahead.")
+    transcript = session.transcript
+
+    try await session.respond(to: "CFO: Based on everything noted (\(transcript)), I'll prepare the budget updates for review.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Investment Banker: With the current insights (\(transcript)), we'll meet again after the new forecasts.")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MedicalCase.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MedicalCase.swift
@@ -1,0 +1,40 @@
+//
+//  MedicalCase.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instructions = """
+    You are a medical team discussing a complex patient case. The experts are:
+    - Cardiologist
+    - Neurologist
+    - Oncologist
+    - Radiologist
+    - Pharmacist
+    Use the role name before each message.
+    """
+
+    let session = LanguageModelSession(instructions: instructions)
+
+    try await session.respond(to: "Cardiologist: The patient has irregular heart rhythms.")
+    var transcript = session.transcript
+
+    try await session.respond(to: "Neurologist: Reviewing the conversation (\(transcript)), I've noticed mild cognitive impairment.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Oncologist: Taking into account our notes (\(transcript)), there are no signs of malignancy in the scans.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Radiologist: With the information so far (\(transcript)), imaging confirms mild inflammation in the lungs.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Pharmacist: In light of the ongoing discussion (\(transcript)), current medication should be adjusted to avoid interaction.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Cardiologist: Based on the discussion so far (\(transcript)), I'll update the treatment plan and monitor progress.")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/SpaceMission.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SpaceMission.swift
@@ -1,0 +1,40 @@
+//
+//  SpaceMission.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instructions = """
+    A space mission team is collaborating on an upcoming launch. The roles include:
+    - Astronaut
+    - Mission Planner
+    - Spacecraft Engineer
+    - Astrophysicist
+    - Flight Surgeon
+    Address each message with the role name first.
+    """
+
+    let session = LanguageModelSession(instructions: instructions)
+
+    try await session.respond(to: "Astronaut: The launch window opens in six months.")
+    var transcript = session.transcript
+
+    try await session.respond(to: "Mission Planner: Considering our discussion (\(transcript)), we'll finalize objectives and timelines.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Spacecraft Engineer: Using the latest updates (\(transcript)), I'll verify the propulsion system readiness.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Astrophysicist: Based on the mission details (\(transcript)), we must analyze solar activity for safety.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Flight Surgeon: Taking all information into account (\(transcript)), crew health screenings begin next week.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Astronaut: With these updates (\(transcript)), everyone prepare your reports for the review meeting.")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/TechPanel.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/TechPanel.swift
@@ -1,0 +1,40 @@
+//
+//  TechPanel.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instructions = """
+    You are a panel of technology experts. The roles are:
+    - AI Researcher
+    - Web Developer
+    - Network Engineer
+    - UI/UX Designer
+    - Database Administrator
+    Follow the role prefix in each message when responding.
+    """
+
+    let session = LanguageModelSession(instructions: instructions)
+
+    try await session.respond(to: "AI Researcher: Let's discuss the new app architecture.")
+    var transcript = session.transcript
+
+    try await session.respond(to: "Web Developer: With the context so far (\(transcript)), a Swift-based web framework would be ideal.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Network Engineer: Considering our discussion (\(transcript)), ensure our API endpoints are optimized for low latency.")
+    transcript = session.transcript
+
+    try await session.respond(to: "UI/UX Designer: Building on the previous points (\(transcript)), the interface needs to be intuitive and accessible.")
+    transcript = session.transcript
+
+    try await session.respond(to: "Database Administrator: Given our conversation (\(transcript)), I'll design the schema to scale with high traffic.")
+    transcript = session.transcript
+
+    try await session.respond(to: "AI Researcher: Based on everything discussed (\(transcript)), let's prototype and reconvene next week.")
+}


### PR DESCRIPTION
## Summary
- update new conversation playgrounds to reference transcript after each message

## Testing
- `swiftc -frontend -typecheck Foundation-Models-Playgrounds/Playgrounds/TechPanel.swift Foundation-Models-Playgrounds/Playgrounds/MedicalCase.swift Foundation-Models-Playgrounds/Playgrounds/SpaceMission.swift Foundation-Models-Playgrounds/Playgrounds/FinancialStrategy.swift Foundation-Models-Playgrounds/Playgrounds/FilmProduction.swift` *(fails: no such module 'FoundationModels')*


------
https://chatgpt.com/codex/tasks/task_e_684a06a2b3a08320b42a7d3d21a090c2