### PR TITLE
Add dynamic tool selection conversation playgrounds

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/DynamicContactOrCalendar.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DynamicContactOrCalendar.swift
@@ -1,0 +1,19 @@
+//
+//  DynamicContactOrCalendar.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/21/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [ContactSearchTool(), CalendarEventTool()],
+        instructions: "Use contact lookup or calendar scheduling based on each request."
+    )
+
+    try await session.respond(to: "Sara: What's Jane Doe's phone number?")
+    try await session.respond(to: "Mike: Schedule our project sync for 2026-09-01T10:00:00Z")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DynamicGameDifficultyOrCalendar.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DynamicGameDifficultyOrCalendar.swift
@@ -1,0 +1,19 @@
+//
+//  DynamicGameDifficultyOrCalendar.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/21/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [GameDifficultyTool(), CalendarEventTool()],
+        instructions: "Adjust game difficulty or add calendar events based on the conversation."
+    )
+
+    try await session.respond(to: "Ethan: Set the game difficulty to 4.")
+    try await session.respond(to: "Sophia: Add dinner with Alex on 2026-10-05T19:00:00Z")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DynamicRecipeOrWorkout.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DynamicRecipeOrWorkout.swift
@@ -1,0 +1,55 @@
+//
+//  DynamicRecipeOrWorkout.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/21/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct RecipeTool: Tool {
+    let name = "generateRecipe"
+    let description = "Create a simple recipe based on a dish"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Dish to prepare")
+        var dish: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let result = GeneratedContent(properties: [
+            "recipe": "Quick recipe for \(arguments.dish)"
+        ])
+        return ToolOutput(result)
+    }
+}
+
+struct WorkoutTool: Tool {
+    let name = "createWorkout"
+    let description = "Generate a brief workout routine"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Focus area or goal")
+        var goal: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let result = GeneratedContent(properties: [
+            "workout": "Workout routine for \(arguments.goal)"
+        ])
+        return ToolOutput(result)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [RecipeTool(), WorkoutTool()],
+        instructions: "Infer whether users want a recipe or a workout plan."
+    )
+
+    try await session.respond(to: "Liam: I'd like something tasty with chicken.")
+    try await session.respond(to: "Noah: Give me a quick leg day routine.")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DynamicSleepOrSteps.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DynamicSleepOrSteps.swift
@@ -1,0 +1,19 @@
+//
+//  DynamicSleepOrSteps.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/21/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [SleepDataTool(), StepCountTool()],
+        instructions: "Answer health questions using the sleep or steps tool as needed."
+    )
+
+    try await session.respond(to: "Emma: How many hours did I sleep last night?")
+    try await session.respond(to: "Olivia: What's my current step count?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DynamicTranslateOrSummary.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DynamicTranslateOrSummary.swift
@@ -1,0 +1,55 @@
+//
+//  DynamicTranslateOrSummary.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/21/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct TranslationTool: Tool {
+    let name = "translateText"
+    let description = "Translate English text to French"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Text to translate")
+        var text: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let result = GeneratedContent(properties: [
+            "translation": "French translation of '\(arguments.text)'"
+        ])
+        return ToolOutput(result)
+    }
+}
+
+struct SummaryTool: Tool {
+    let name = "summarizeText"
+    let description = "Provide a short summary of a passage"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Text to summarize")
+        var text: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let result = GeneratedContent(properties: [
+            "summary": "Summary of '\(arguments.text)'"
+        ])
+        return ToolOutput(result)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [TranslationTool(), SummaryTool()],
+        instructions: "Decide whether to translate or summarize based on each user's question."
+    )
+
+    try await session.respond(to: "Eve: Translate 'Good morning' to French.")
+    try await session.respond(to: "Frank: Summarize the importance of swift concurrency.")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DynamicTriviaOrDarkMode.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DynamicTriviaOrDarkMode.swift
@@ -1,0 +1,19 @@
+//
+//  DynamicTriviaOrDarkMode.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/21/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [TriviaScoreTool(), DarkModeTool()],
+        instructions: "Use the trivia or dark mode tool depending on each speaker's intent."
+    )
+
+    try await session.respond(to: "Ava: Set my trivia score to 10.")
+    try await session.respond(to: "Mia: Please enable dark mode.")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/DynamicWeatherOrStock.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/DynamicWeatherOrStock.swift
@@ -1,0 +1,38 @@
+//
+//  DynamicWeatherOrStock.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/21/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct WeatherTool: Tool {
+    let name = "getWeather"
+    let description = "Get the forecast for a city"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "City name for the forecast")
+        var city: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "city": arguments.city,
+            "forecast": "Sunny and 72F"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [WeatherTool(), StockPriceTool()],
+        instructions: "Use the weather or stock tool depending on who is speaking."
+    )
+
+    try await session.respond(to: "Alice: What's the weather in San Jose tomorrow?")
+    try await session.respond(to: "Bob: Give me the latest TSLA price.")
+}


### PR DESCRIPTION
## Summary
- add WeatherTool and showcase dynamic conversations that select between tools
- include translation, recipe, workout, trivia, sleep, contact, and calendar examples

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684a0b462bc4832098b1b2f970f2f713