### PR TITLE
Add additional visionOS playgrounds

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/BugReportSummarizer.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/BugReportSummarizer.swift
@@ -1,0 +1,21 @@
+//
+//  BugReportSummarizer.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Key bug report themes")
+struct BugReportSummary {
+    @Guide(description: "Common issues summarized from bug reports", .count(1...5))
+    var themes: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Summarize recent bug reports for a mobile app")
+    let summary = try await session.respond(to: prompt, generating: BugReportSummary.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ContentPlanner.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ContentPlanner.swift
@@ -1,0 +1,21 @@
+//
+//  ContentPlanner.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Social media content idea")
+struct ContentIdea {
+    var day: String
+    var post: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Plan a week's worth of travel blog posts")
+    let plan = try await session.respond(to: prompt, generating: [ContentIdea].self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/EmojiTranslator.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/EmojiTranslator.swift
@@ -1,0 +1,15 @@
+//
+//  EmojiTranslator.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Translate 'have a great day' into emojis")
+    let emojis = try await session.respond(to: prompt, generating: String.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/FashionRecommendation.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/FashionRecommendation.swift
@@ -1,0 +1,21 @@
+//
+//  FashionRecommendation.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Outfit suggestion")
+struct OutfitSuggestion {
+    var occasion: String
+    var items: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Suggest an autumn outfit for a casual dinner")
+    let outfit = try await session.respond(to: prompt, generating: OutfitSuggestion.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MusicRecommendation.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MusicRecommendation.swift
@@ -1,0 +1,21 @@
+//
+//  MusicRecommendation.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Music suggestion")
+struct MusicSuggestion {
+    var track: String
+    var artist: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Recommend an upbeat song for exercising")
+    let music = try await session.respond(to: prompt, generating: MusicSuggestion.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/PitchDeckOutline.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/PitchDeckOutline.swift
@@ -1,0 +1,22 @@
+//
+//  PitchDeckOutline.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Pitch deck slide")
+struct PitchSlide {
+    var title: String
+    @Guide(description: "Bullet points for the slide", .count(1...5))
+    var bullets: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Outline a startup pitch deck for a meal delivery app")
+    let deck = try await session.respond(to: prompt, generating: [PitchSlide].self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ProductComparison.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ProductComparison.swift
@@ -1,0 +1,22 @@
+//
+//  ProductComparison.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Feature comparison row")
+struct ComparisonRow {
+    var feature: String
+    var productA: String
+    var productB: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Compare two smartphones: Phone X and Phone Y")
+    let table = try await session.respond(to: prompt, generating: [ComparisonRow].self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/RoadTripPackingList.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/RoadTripPackingList.swift
@@ -1,0 +1,21 @@
+//
+//  RoadTripPackingList.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Packing list for a trip")
+struct PackingList {
+    @Guide(description: "Items to bring", .count(1...20))
+    var items: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Create a packing checklist for a 5-day summer road trip")
+    let list = try await session.respond(to: prompt, generating: PackingList.self)
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`AutocompleteAssistant.swift`](Foundation-Models-Playgrounds/Playgrounds/AutocompleteAssistant.swift) – Produces text completions for short prompts.
 - [`Basic.swift`](Foundation-Models-Playgrounds/Playgrounds/Basic.swift) – A minimal example of chatting with a helpful assistant.
 - [`BasicChat.swift`](Foundation-Models-Playgrounds/Playgrounds/BasicChat.swift) – Shows a simple back-and-forth chat session.
+- [`BugReportSummarizer.swift`](Foundation-Models-Playgrounds/Playgrounds/BugReportSummarizer.swift) – Summarizes a set of software bug reports into key themes.
 - [`CalendarEventTool.swift`](Foundation-Models-Playgrounds/Playgrounds/CalendarEventTool.swift) – Demonstrates a tool that adds events to a calendar.
 - [`ChainedPrompts.swift`](Foundation-Models-Playgrounds/Playgrounds/ChainedPrompts.swift) – Uses multiple model calls to build a story from a headline.
 - [`CharacterChat.swift`](Foundation-Models-Playgrounds/Playgrounds/CharacterChat.swift) – Role-plays as a medieval knight in conversation.
@@ -17,6 +18,7 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`CodeSummary.swift`](Foundation-Models-Playgrounds/Playgrounds/CodeSummary.swift) – Summarizes the purpose of a short code sample.
 - [`ConstrainedCharacterProfile.swift`](Foundation-Models-Playgrounds/Playgrounds/ConstrainedCharacterProfile.swift) – Generates a character profile with guides enforcing structure.
 - [`ContactLookupTool.swift`](Foundation-Models-Playgrounds/Playgrounds/ContactLookupTool.swift) – Implements a custom tool to search a contact list.
+- [`ContentPlanner.swift`](Foundation-Models-Playgrounds/Playgrounds/ContentPlanner.swift) – Outlines a weekly plan for social media posts based on a topic.
 - [`ConversationMemory.swift`](Foundation-Models-Playgrounds/Playgrounds/ConversationMemory.swift) – Shows how to retrieve the transcript of a session.
 - [`DailyMotivation.swift`](Foundation-Models-Playgrounds/Playgrounds/DailyMotivation.swift) – Provides a quick motivational quote.
 - [`DailyQuote.swift`](Foundation-Models-Playgrounds/Playgrounds/DailyQuote.swift) – Creates an inspirational quote using a generable structure.
@@ -31,7 +33,9 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`DynamicTriviaOrDarkMode.swift`](Foundation-Models-Playgrounds/Playgrounds/DynamicTriviaOrDarkMode.swift) – Mixes a trivia score tool with the dark mode tool.
 - [`DynamicWeatherOrStock.swift`](Foundation-Models-Playgrounds/Playgrounds/DynamicWeatherOrStock.swift) – Uses weather or stock quote tools depending on request.
 - [`EmailComposition.swift`](Foundation-Models-Playgrounds/Playgrounds/EmailComposition.swift) – Generates a short email from a prompt.
+- [`EmojiTranslator.swift`](Foundation-Models-Playgrounds/Playgrounds/EmojiTranslator.swift) – Converts short sentences into strings of emojis.
 - [`ExplainConcept.swift`](Foundation-Models-Playgrounds/Playgrounds/ExplainConcept.swift) – Explains a technical concept in simple terms.
+- [`FashionRecommendation.swift`](Foundation-Models-Playgrounds/Playgrounds/FashionRecommendation.swift) – Suggests outfit combinations for an occasion or season.
 - [`FilmProduction.swift`](Foundation-Models-Playgrounds/Playgrounds/FilmProduction.swift) – Provides a short film production outline.
 - [`FinancialStrategy.swift`](Foundation-Models-Playgrounds/Playgrounds/FinancialStrategy.swift) – Offers financial planning suggestions.
 - [`FrenchTranslation.swift`](Foundation-Models-Playgrounds/Playgrounds/FrenchTranslation.swift) – Translates phrases into French.
@@ -48,15 +52,19 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`ModelAvailability.swift`](Foundation-Models-Playgrounds/Playgrounds/ModelAvailability.swift) – Checks the availability status of the system model.
 - [`MovieNightRecommendation.swift`](Foundation-Models-Playgrounds/Playgrounds/MovieNightRecommendation.swift) – Recommends a movie with a rating and reason.
 - [`MusicAlbum.swift`](Foundation-Models-Playgrounds/Playgrounds/MusicAlbum.swift) – Describes a music album using a generable structure.
+- [`MusicRecommendation.swift`](Foundation-Models-Playgrounds/Playgrounds/MusicRecommendation.swift) – Suggests music tracks or albums based on mood.
 - [`NaturePoem.swift`](Foundation-Models-Playgrounds/Playgrounds/NaturePoem.swift) – Creates a short poem about nature.
 - [`NestedGenerable.swift`](Foundation-Models-Playgrounds/Playgrounds/NestedGenerable.swift) – Demonstrates nested generable types.
 - [`NewsHeadlineTool.swift`](Foundation-Models-Playgrounds/Playgrounds/NewsHeadlineTool.swift) – Tool that generates a headline from news text.
 - [`NewsSummary.swift`](Foundation-Models-Playgrounds/Playgrounds/NewsSummary.swift) – Summarizes news articles concisely.
 - [`NovelOutline.swift`](Foundation-Models-Playgrounds/Playgrounds/NovelOutline.swift) – Produces a brief outline for a novel idea.
 - [`NumericConversion.swift`](Foundation-Models-Playgrounds/Playgrounds/NumericConversion.swift) – Converts numbers between formats.
+- [`PitchDeckOutline.swift`](Foundation-Models-Playgrounds/Playgrounds/PitchDeckOutline.swift) – Provides a structured outline for a startup pitch deck.
+- [`ProductComparison.swift`](Foundation-Models-Playgrounds/Playgrounds/ProductComparison.swift) – Summarizes differences between two products in a table.
 - [`RecipeMaker.swift`](Foundation-Models-Playgrounds/Playgrounds/RecipeMaker.swift) – Generates a recipe based on user ingredients.
 - [`ResumeGenerator.swift`](Foundation-Models-Playgrounds/Playgrounds/ResumeGenerator.swift) – Builds a simple resume with highlights.
 - [`RiddleMaker.swift`](Foundation-Models-Playgrounds/Playgrounds/RiddleMaker.swift) – Creates a riddle for entertainment.
+- [`RoadTripPackingList.swift`](Foundation-Models-Playgrounds/Playgrounds/RoadTripPackingList.swift) – Generates a checklist for packing on a road trip.
 - [`SQLQueryAssistant.swift`](Foundation-Models-Playgrounds/Playgrounds/SQLQueryAssistant.swift) – Converts natural language into SQL queries.
 - [`SafetyGuidedGeneration.swift`](Foundation-Models-Playgrounds/Playgrounds/SafetyGuidedGeneration.swift) – Uses guardrails to filter unsafe output.
 - [`SafetyInputBoundaries.swift`](Foundation-Models-Playgrounds/Playgrounds/SafetyInputBoundaries.swift) – Adjusts prompts to keep them wholesome.


### PR DESCRIPTION
## Summary
- add eight new visionOS playgrounds demonstrating Foundation Model features
- document the new playgrounds in the catalog

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684b29f538c88320ab472dc27c2f0eb1