### PR TITLE
Add date and regex generable examples

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/MoonLandingDate.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MoonLandingDate.swift
@@ -1,0 +1,25 @@
+//
+//  MoonLandingDate.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Date of a historical event")
+struct CalendarDate {
+    @Guide(description: "Month number", .range(1...12))
+    var month: Int
+    @Guide(description: "Day of the month", .range(1...31))
+    var day: Int
+    @Guide(description: "Four digit year", .range(1900...2100))
+    var year: Int
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("When was the first moon landing?")
+    let date = try await session.respond(to: prompt, generating: CalendarDate.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/NextLeapDay.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/NextLeapDay.swift
@@ -1,0 +1,25 @@
+//
+//  NextLeapDay.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Date of the next leap day")
+struct SimpleDate {
+    @Guide(description: "Month number", .range(1...12))
+    var month: Int
+    @Guide(description: "Day of the month", .range(1...31))
+    var day: Int
+    @Guide(description: "Four digit year", .range(1900...2100))
+    var year: Int
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("When is the next leap day after 2026?")
+    let date = try await session.respond(to: prompt, generating: SimpleDate.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/RegexEmail.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/RegexEmail.swift
@@ -1,0 +1,23 @@
+//
+//  RegexEmail.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+let emailPattern = #/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/#
+
+@Generable(description: "Match for an email address")
+struct EmailAddress {
+    @Guide(description: "Value matching an email format", .matches(emailPattern))
+    var value: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Give me a sample email address.")
+    let address = try await session.respond(to: prompt, generating: EmailAddress.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/RegexPhoneNumber.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/RegexPhoneNumber.swift
@@ -1,0 +1,23 @@
+//
+//  RegexPhoneNumber.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+let phonePattern = #/\d{3}-\d{3}-\d{4}/#
+
+@Generable(description: "Phone number in 123-456-7890 format")
+struct PhoneNumber {
+    @Guide(description: "String that matches a U.S. phone number", .matches(phonePattern))
+    var value: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Provide a contact phone number in 123-456-7890 format.")
+    let phone = try await session.respond(to: prompt, generating: PhoneNumber.self)
+}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`MarketingTagline.swift`](Foundation-Models-Playgrounds/Playgrounds/MarketingTagline.swift) – Suggests a catchy marketing tagline.
 - [`MedicalCase.swift`](Foundation-Models-Playgrounds/Playgrounds/MedicalCase.swift) – Simulates a multi-expert discussion of a patient case.
 - [`ModelAvailability.swift`](Foundation-Models-Playgrounds/Playgrounds/ModelAvailability.swift) – Checks the availability status of the system model.
+- [`MoonLandingDate.swift`](Foundation-Models-Playgrounds/Playgrounds/MoonLandingDate.swift) – Retrieves the date of the first moon landing.
 - [`MovieNightRecommendation.swift`](Foundation-Models-Playgrounds/Playgrounds/MovieNightRecommendation.swift) – Recommends a movie with a rating and reason.
 - [`MusicAlbum.swift`](Foundation-Models-Playgrounds/Playgrounds/MusicAlbum.swift) – Describes a music album using a generable structure.
 - [`MusicRecommendation.swift`](Foundation-Models-Playgrounds/Playgrounds/MusicRecommendation.swift) – Suggests music tracks or albums based on mood.
@@ -57,11 +58,14 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`NestedGenerable.swift`](Foundation-Models-Playgrounds/Playgrounds/NestedGenerable.swift) – Demonstrates nested generable types.
 - [`NewsHeadlineTool.swift`](Foundation-Models-Playgrounds/Playgrounds/NewsHeadlineTool.swift) – Tool that generates a headline from news text.
 - [`NewsSummary.swift`](Foundation-Models-Playgrounds/Playgrounds/NewsSummary.swift) – Summarizes news articles concisely.
+- [`NextLeapDay.swift`](Foundation-Models-Playgrounds/Playgrounds/NextLeapDay.swift) – Shows the date of the next leap day.
 - [`NovelOutline.swift`](Foundation-Models-Playgrounds/Playgrounds/NovelOutline.swift) – Produces a brief outline for a novel idea.
 - [`NumericConversion.swift`](Foundation-Models-Playgrounds/Playgrounds/NumericConversion.swift) – Converts numbers between formats.
 - [`PitchDeckOutline.swift`](Foundation-Models-Playgrounds/Playgrounds/PitchDeckOutline.swift) – Provides a structured outline for a startup pitch deck.
 - [`ProductComparison.swift`](Foundation-Models-Playgrounds/Playgrounds/ProductComparison.swift) – Summarizes differences between two products in a table.
 - [`RecipeMaker.swift`](Foundation-Models-Playgrounds/Playgrounds/RecipeMaker.swift) – Generates a recipe based on user ingredients.
+- [`RegexEmail.swift`](Foundation-Models-Playgrounds/Playgrounds/RegexEmail.swift) – Generates a string that matches an email pattern.
+- [`RegexPhoneNumber.swift`](Foundation-Models-Playgrounds/Playgrounds/RegexPhoneNumber.swift) – Produces a phone number using a regex guide.
 - [`ResumeGenerator.swift`](Foundation-Models-Playgrounds/Playgrounds/ResumeGenerator.swift) – Builds a simple resume with highlights.
 - [`RiddleMaker.swift`](Foundation-Models-Playgrounds/Playgrounds/RiddleMaker.swift) – Creates a riddle for entertainment.
 - [`RoadTripPackingList.swift`](Foundation-Models-Playgrounds/Playgrounds/RoadTripPackingList.swift) – Generates a checklist for packing on a road trip.


### PR DESCRIPTION
## Summary
- showcase MoonLandingDate for date generable structure
- show NextLeapDay date example
- demonstrate regex guide for email addresses
- demonstrate regex guide for phone numbers
- document new playgrounds in README

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684b2e93def88320b456fc2259fa742f