### PR TITLE
Add new examples

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/CodeReviewAssistant.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CodeReviewAssistant.swift
@@ -1,0 +1,20 @@
+//
+//  CodeReviewAssistant.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You are a helpful code reviewer. Provide suggestions to improve readability."
+    let session = LanguageModelSession(instructions: instruction)
+    let code = """
+    func greet(name: String){print("Hello, \(name)!")}
+    """
+    let prompt = Prompt("Review the following Swift code:\n\n\(code)")
+    let options = GenerationOptions(temperature: 0.2, maximumResponseTokens: 1000)
+    let response = try await session.respond(to: prompt, options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/CodingChallengeGenerator.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CodingChallengeGenerator.swift
@@ -1,0 +1,21 @@
+//
+//  CodingChallengeGenerator.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Programming challenge with a hint")
+struct CodingChallenge {
+    var challenge: String
+    var hint: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Give me a beginner Swift programming challenge")
+    let challenge = try await session.respond(to: prompt, generating: CodingChallenge.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/InterviewQuestionCoach.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/InterviewQuestionCoach.swift
@@ -1,0 +1,21 @@
+//
+//  InterviewQuestionCoach.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Sample interview question with a short model answer")
+struct InterviewQA {
+    var question: String
+    var answer: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Provide an iOS developer interview question with a short answer")
+    let qa = try await session.respond(to: prompt, generating: InterviewQA.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/LanguageIdiomTutor.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/LanguageIdiomTutor.swift
@@ -1,0 +1,22 @@
+//
+//  LanguageIdiomTutor.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Meaning and example sentence for an idiom")
+struct IdiomExplanation {
+    var meaning: String
+    @Guide(description: "Example sentence")
+    var example: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Explain the English idiom 'break the ice' and provide an example sentence")
+    let idiom = try await session.respond(to: prompt, generating: IdiomExplanation.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MathProblemSolver.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MathProblemSolver.swift
@@ -1,0 +1,23 @@
+//
+//  MathProblemSolver.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Solution to a math problem with steps")
+struct MathSolution {
+    var solution: String
+    @Guide(description: "Step-by-step explanation")
+    var steps: [String]
+}
+
+#Playground {
+    let instruction = "You solve math problems step by step."
+    let session = LanguageModelSession(instructions: instruction)
+    let prompt = Prompt("Solve for x: 2x + 3 = 11")
+    let answer = try await session.respond(to: prompt, generating: MathSolution.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/VocabularyQuizMaker.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/VocabularyQuizMaker.swift
@@ -1,0 +1,23 @@
+//
+//  VocabularyQuizMaker.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Multiple-choice vocabulary question")
+struct QuizQuestion {
+    var question: String
+    @Guide(description: "Answer options", .count(4))
+    var choices: [String]
+    var answer: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Create a vocabulary quiz question using the word 'ephemeral'")
+    let quiz = try await session.respond(to: prompt, generating: QuizQuestion.self)
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`ChatInstructions.swift`](Foundation-Models-Playgrounds/Playgrounds/ChatInstructions.swift) – Sets instructions dynamically for each chat run.
 - [`CodeCompletion.swift`](Foundation-Models-Playgrounds/Playgrounds/CodeCompletion.swift) – Generates code completions given a snippet.
 - [`CodeRefactor.swift`](Foundation-Models-Playgrounds/Playgrounds/CodeRefactor.swift) – Refactors code to improve clarity.
+- [`CodeReviewAssistant.swift`](Foundation-Models-Playgrounds/Playgrounds/CodeReviewAssistant.swift) – Offers feedback on Swift code to improve readability.
 - [`CodeSummary.swift`](Foundation-Models-Playgrounds/Playgrounds/CodeSummary.swift) – Summarizes the purpose of a short code sample.
+- [`CodingChallengeGenerator.swift`](Foundation-Models-Playgrounds/Playgrounds/CodingChallengeGenerator.swift) – Supplies short programming puzzles with hints.
 - [`ConstrainedCharacterProfile.swift`](Foundation-Models-Playgrounds/Playgrounds/ConstrainedCharacterProfile.swift) – Generates a character profile with guides enforcing structure.
 - [`ContactLookupTool.swift`](Foundation-Models-Playgrounds/Playgrounds/ContactLookupTool.swift) – Implements a custom tool to search a contact list.
 - [`ContentPlanner.swift`](Foundation-Models-Playgrounds/Playgrounds/ContentPlanner.swift) – Outlines a weekly plan for social media posts based on a topic.
@@ -44,10 +46,13 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`GuardrailViolation.swift`](Foundation-Models-Playgrounds/Playgrounds/GuardrailViolation.swift) – Shows how guardrails handle unsafe requests.
 - [`Haiku.swift`](Foundation-Models-Playgrounds/Playgrounds/Haiku.swift) – Writes a short haiku about a topic.
 - [`HealthStepsTool.swift`](Foundation-Models-Playgrounds/Playgrounds/HealthStepsTool.swift) – Records a daily step count via a tool.
+- [`InterviewQuestionCoach.swift`](Foundation-Models-Playgrounds/Playgrounds/InterviewQuestionCoach.swift) – Produces sample interview questions with brief answers.
 - [`JSONGenerator.swift`](Foundation-Models-Playgrounds/Playgrounds/JSONGenerator.swift) – Produces structured JSON from a model response.
 - [`LanguageFlashCard.swift`](Foundation-Models-Playgrounds/Playgrounds/LanguageFlashCard.swift) – Generates flash cards for learning new words.
+- [`LanguageIdiomTutor.swift`](Foundation-Models-Playgrounds/Playgrounds/LanguageIdiomTutor.swift) – Explains idioms with usage examples.
 - [`LanguageTriage.swift`](Foundation-Models-Playgrounds/Playgrounds/LanguageTriage.swift) – Classifies user requests by topic.
 - [`MarketingTagline.swift`](Foundation-Models-Playgrounds/Playgrounds/MarketingTagline.swift) – Suggests a catchy marketing tagline.
+- [`MathProblemSolver.swift`](Foundation-Models-Playgrounds/Playgrounds/MathProblemSolver.swift) – Solves algebra problems step by step.
 - [`MedicalCase.swift`](Foundation-Models-Playgrounds/Playgrounds/MedicalCase.swift) – Simulates a multi-expert discussion of a patient case.
 - [`ModelAvailability.swift`](Foundation-Models-Playgrounds/Playgrounds/ModelAvailability.swift) – Checks the availability status of the system model.
 - [`MoonLandingDate.swift`](Foundation-Models-Playgrounds/Playgrounds/MoonLandingDate.swift) – Retrieves the date of the first moon landing.
@@ -93,6 +98,7 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`TrendingTopics.swift`](Foundation-Models-Playgrounds/Playgrounds/TrendingTopics.swift) – Lists currently trending discussion topics.
 - [`TriviaScoreTool.swift`](Foundation-Models-Playgrounds/Playgrounds/TriviaScoreTool.swift) – Maintains a trivia score via a tool.
 - [`VegetarianMenu.swift`](Foundation-Models-Playgrounds/Playgrounds/VegetarianMenu.swift) – Suggests a vegetarian dinner menu.
+- [`VocabularyQuizMaker.swift`](Foundation-Models-Playgrounds/Playgrounds/VocabularyQuizMaker.swift) – Generates multiple-choice vocabulary quizzes.
 - [`WeatherReport.swift`](Foundation-Models-Playgrounds/Playgrounds/WeatherReport.swift) – Generates a brief weather report.
 - [`WorkoutPlan.swift`](Foundation-Models-Playgrounds/Playgrounds/WorkoutPlan.swift) – Creates a workout plan for the week.
 - [`WorkoutSchedule.swift`](Foundation-Models-Playgrounds/Playgrounds/WorkoutSchedule.swift) – Produces a workout schedule with dates.


### PR DESCRIPTION
## Summary
- add InterviewQuestionCoach, LanguageIdiomTutor, CodeReviewAssistant, VocabularyQuizMaker, CodingChallengeGenerator, and MathProblemSolver playgrounds
- document the new playgrounds in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b3bd6c94083208b28627822d69ab3