### PR TITLE
Add additional Swift playground examples

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/BookSeriesSummary.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/BookSeriesSummary.swift
@@ -1,0 +1,21 @@
+//
+//  BookSeriesSummary.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Short summary for a book in a series")
+struct BookSummary {
+    var title: String
+    var summary: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Summarize the first three books in the Dune series")
+    let summaries = try await session.respond(to: prompt, generating: [BookSummary].self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/EmailResponseDraft.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/EmailResponseDraft.swift
@@ -1,0 +1,19 @@
+//
+//  EmailResponseDraft.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let instruction = "You write concise email replies."
+    let session = LanguageModelSession(instructions: instruction)
+    let options = GenerationOptions(temperature: 0.3, maximumResponseTokens: 1000)
+    let prompts = [
+        "Draft a short reply thanking a colleague for sending the meeting notes."
+    ]
+    let response = try await session.respond(to: prompts[0], options: options)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/TravelBudgetEstimator.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/TravelBudgetEstimator.swift
@@ -1,0 +1,25 @@
+//
+//  TravelBudgetEstimator.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Estimated travel budget in USD")
+struct TravelBudget {
+    @Guide(description: "Approximate total cost in US dollars")
+    var totalCost: Int
+    @Guide(description: "Estimated cost per day in US dollars")
+    var dailyCost: Int
+    @Guide(description: "Main expense categories", .count(1...5))
+    var categories: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Estimate the budget for a 5-day trip to Paris")
+    let budget = try await session.respond(to: prompt, generating: TravelBudget.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/TriviaQuestionWriter.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/TriviaQuestionWriter.swift
@@ -1,0 +1,21 @@
+//
+//  TriviaQuestionWriter.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Simple trivia question with answer")
+struct TriviaQA {
+    var question: String
+    var answer: String
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("Write a trivia question about world history")
+    let qa = try await session.respond(to: prompt, generating: TriviaQA.self)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/VacationPackingHelper.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/VacationPackingHelper.swift
@@ -1,0 +1,21 @@
+//
+//  VacationPackingHelper.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/20/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Items to pack for a trip")
+struct PackingList {
+    @Guide(description: "Recommended items", .count(1...15))
+    var items: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+    let prompt = Prompt("What should I pack for a week-long hiking trip in the Rockies?")
+    let list = try await session.respond(to: prompt, generating: PackingList.self)
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`AutocompleteAssistant.swift`](Foundation-Models-Playgrounds/Playgrounds/AutocompleteAssistant.swift) – Produces text completions for short prompts.
 - [`Basic.swift`](Foundation-Models-Playgrounds/Playgrounds/Basic.swift) – A minimal example of chatting with a helpful assistant.
 - [`BasicChat.swift`](Foundation-Models-Playgrounds/Playgrounds/BasicChat.swift) – Shows a simple back-and-forth chat session.
+- [`BookSeriesSummary.swift`](Foundation-Models-Playgrounds/Playgrounds/BookSeriesSummary.swift) – Summarizes multiple books in a series.
 - [`BugReportSummarizer.swift`](Foundation-Models-Playgrounds/Playgrounds/BugReportSummarizer.swift) – Summarizes a set of software bug reports into key themes.
 - [`CalendarEventTool.swift`](Foundation-Models-Playgrounds/Playgrounds/CalendarEventTool.swift) – Demonstrates a tool that adds events to a calendar.
 - [`ChainedPrompts.swift`](Foundation-Models-Playgrounds/Playgrounds/ChainedPrompts.swift) – Uses multiple model calls to build a story from a headline.
@@ -35,6 +36,7 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`DynamicTriviaOrDarkMode.swift`](Foundation-Models-Playgrounds/Playgrounds/DynamicTriviaOrDarkMode.swift) – Mixes a trivia score tool with the dark mode tool.
 - [`DynamicWeatherOrStock.swift`](Foundation-Models-Playgrounds/Playgrounds/DynamicWeatherOrStock.swift) – Uses weather or stock quote tools depending on request.
 - [`EmailComposition.swift`](Foundation-Models-Playgrounds/Playgrounds/EmailComposition.swift) – Generates a short email from a prompt.
+- [`EmailResponseDraft.swift`](Foundation-Models-Playgrounds/Playgrounds/EmailResponseDraft.swift) – Drafts a concise reply to an email.
 - [`EmojiTranslator.swift`](Foundation-Models-Playgrounds/Playgrounds/EmojiTranslator.swift) – Converts short sentences into strings of emojis.
 - [`ExplainConcept.swift`](Foundation-Models-Playgrounds/Playgrounds/ExplainConcept.swift) – Explains a technical concept in simple terms.
 - [`FashionRecommendation.swift`](Foundation-Models-Playgrounds/Playgrounds/FashionRecommendation.swift) – Suggests outfit combinations for an occasion or season.
@@ -94,9 +96,12 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 - [`TranscriptReview.swift`](Foundation-Models-Playgrounds/Playgrounds/TranscriptReview.swift) – Demonstrates capturing and reviewing a transcript.
 - [`TranscriptSummarizer.swift`](Foundation-Models-Playgrounds/Playgrounds/TranscriptSummarizer.swift) – Summarizes a session transcript at the end.
 - [`Translate.swift`](Foundation-Models-Playgrounds/Playgrounds/Translate.swift) – Translates text between languages.
+- [`TravelBudgetEstimator.swift`](Foundation-Models-Playgrounds/Playgrounds/TravelBudgetEstimator.swift) – Estimates travel costs for a trip.
 - [`TravelItinerary.swift`](Foundation-Models-Playgrounds/Playgrounds/TravelItinerary.swift) – Plans a travel itinerary for a destination.
 - [`TrendingTopics.swift`](Foundation-Models-Playgrounds/Playgrounds/TrendingTopics.swift) – Lists currently trending discussion topics.
+- [`TriviaQuestionWriter.swift`](Foundation-Models-Playgrounds/Playgrounds/TriviaQuestionWriter.swift) – Generates a trivia question with its answer.
 - [`TriviaScoreTool.swift`](Foundation-Models-Playgrounds/Playgrounds/TriviaScoreTool.swift) – Maintains a trivia score via a tool.
+- [`VacationPackingHelper.swift`](Foundation-Models-Playgrounds/Playgrounds/VacationPackingHelper.swift) – Suggests items to pack for a vacation.
 - [`VegetarianMenu.swift`](Foundation-Models-Playgrounds/Playgrounds/VegetarianMenu.swift) – Suggests a vegetarian dinner menu.
 - [`VocabularyQuizMaker.swift`](Foundation-Models-Playgrounds/Playgrounds/VocabularyQuizMaker.swift) – Generates multiple-choice vocabulary quizzes.
 - [`WeatherReport.swift`](Foundation-Models-Playgrounds/Playgrounds/WeatherReport.swift) – Generates a brief weather report.


### PR DESCRIPTION
## Summary
- add `TravelBudgetEstimator` to generate trip cost estimates
- add `BookSeriesSummary` to summarize books in a series
- add `VacationPackingHelper` to suggest packing items
- add `TriviaQuestionWriter` to produce trivia Q&A
- add `EmailResponseDraft` to draft a short email reply
- update README with the new playgrounds

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_684b43335cfc8320925cf25adcbddf3a