### PR TITLE
Add new multi-tool playgrounds

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/AnimalInfoTools.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/AnimalInfoTools.swift
@@ -1,0 +1,77 @@
+//
+//  AnimalInfoTools.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/24/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct AnimalFactTool: Tool {
+    let name = "animalFact"
+    let description = "Provide a quick fact about an animal"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Animal name")
+        var animal: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "animal": arguments.animal,
+            "fact": "This animal is fascinating"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct AnimalHabitatTool: Tool {
+    let name = "animalHabitat"
+    let description = "Describe the habitat of an animal"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Animal name")
+        var animal: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "animal": arguments.animal,
+            "habitat": "Typically found in forests"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct AnimalDietTool: Tool {
+    let name = "animalDiet"
+    let description = "Explain what an animal eats"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Animal name")
+        var animal: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "animal": arguments.animal,
+            "diet": "Mostly plants"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [AnimalFactTool(), AnimalHabitatTool(), AnimalDietTool()],
+        instructions: "Use animal tools to answer wildlife questions"
+    )
+
+    try await session.respond(to: "Give me a fact about pandas")
+    try await session.respond(to: "Where do pandas live?")
+    try await session.respond(to: "What do pandas eat?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/CarInfoTools.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CarInfoTools.swift
@@ -1,0 +1,77 @@
+//
+//  CarInfoTools.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/24/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct CarPriceTool: Tool {
+    let name = "carPrice"
+    let description = "Return the starting price of a car model"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Car model")
+        var model: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "model": arguments.model,
+            "price": "$30,000"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct CarFuelEconomyTool: Tool {
+    let name = "carFuelEconomy"
+    let description = "Show the fuel economy of a car"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Car model")
+        var model: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "model": arguments.model,
+            "mpg": 35
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct CarDealerTool: Tool {
+    let name = "carDealer"
+    let description = "Find a nearby dealer for a car model"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Car model")
+        var model: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "model": arguments.model,
+            "dealer": "Local Motors"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [CarPriceTool(), CarFuelEconomyTool(), CarDealerTool()],
+        instructions: "Use car tools to answer automobile questions"
+    )
+
+    try await session.respond(to: "What is the price of the ExampleCar?")
+    try await session.respond(to: "How fuel efficient is the ExampleCar?")
+    try await session.respond(to: "Where can I buy the ExampleCar?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/CityInfoTools.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/CityInfoTools.swift
@@ -1,0 +1,77 @@
+//
+//  CityInfoTools.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/24/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct CityPopulationTool: Tool {
+    let name = "cityPopulation"
+    let description = "Look up the population of a city"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "City name")
+        var city: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "city": arguments.city,
+            "population": "1,000,000"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct CityAreaTool: Tool {
+    let name = "cityArea"
+    let description = "Retrieve the total area of a city"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "City name")
+        var city: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "city": arguments.city,
+            "area": "180 sq mi"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct CityTimezoneTool: Tool {
+    let name = "cityTimezone"
+    let description = "Return the timezone for a city"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "City name")
+        var city: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "city": arguments.city,
+            "timezone": "PST"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [CityPopulationTool(), CityAreaTool(), CityTimezoneTool()],
+        instructions: "Use the city info tools to answer questions"
+    )
+
+    try await session.respond(to: "What is the population of San Jose?")
+    try await session.respond(to: "How big is San Jose?")
+    try await session.respond(to: "What timezone is San Jose in?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/HistoricalEventTools.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/HistoricalEventTools.swift
@@ -1,0 +1,77 @@
+//
+//  HistoricalEventTools.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/24/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct HistoricalEventDateTool: Tool {
+    let name = "eventDate"
+    let description = "Give the date of a historical event"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Event name")
+        var event: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "event": arguments.event,
+            "date": "January 1, 1900"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct HistoricalEventLocationTool: Tool {
+    let name = "eventLocation"
+    let description = "Provide the location of a historical event"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Event name")
+        var event: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "event": arguments.event,
+            "location": "Somewhere on Earth"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct HistoricalEventFigureTool: Tool {
+    let name = "eventFigure"
+    let description = "Mention a key figure in a historical event"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Event name")
+        var event: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "event": arguments.event,
+            "figure": "Important Person"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [HistoricalEventDateTool(), HistoricalEventLocationTool(), HistoricalEventFigureTool()],
+        instructions: "Use historical tools for event questions"
+    )
+
+    try await session.respond(to: "When was the Example Event?")
+    try await session.respond(to: "Where did the Example Event happen?")
+    try await session.respond(to: "Name someone involved in the Example Event")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MovieInfoTools.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MovieInfoTools.swift
@@ -1,0 +1,77 @@
+//
+//  MovieInfoTools.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/24/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct MovieRatingTool: Tool {
+    let name = "movieRating"
+    let description = "Provide the rating for a movie"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Movie title")
+        var title: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "title": arguments.title,
+            "rating": "4 stars"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct MovieDirectorTool: Tool {
+    let name = "movieDirector"
+    let description = "Return the director of a movie"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Movie title")
+        var title: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "title": arguments.title,
+            "director": "A. Filmmaker"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct MovieCastTool: Tool {
+    let name = "movieCast"
+    let description = "List the main cast of a movie"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Movie title")
+        var title: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "title": arguments.title,
+            "cast": "Famous Actor, Another Star"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [MovieRatingTool(), MovieDirectorTool(), MovieCastTool()],
+        instructions: "Use movie tools for film trivia"
+    )
+
+    try await session.respond(to: "What rating did Example Movie get?")
+    try await session.respond(to: "Who directed Example Movie?")
+    try await session.respond(to: "Who's in the cast of Example Movie?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/PlanetInfoTools.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/PlanetInfoTools.swift
@@ -1,0 +1,77 @@
+//
+//  PlanetInfoTools.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/24/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct PlanetDistanceTool: Tool {
+    let name = "planetDistance"
+    let description = "Distance of a planet from the sun"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Planet name")
+        var planet: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "planet": arguments.planet,
+            "distance": "100 million km"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct PlanetGravityTool: Tool {
+    let name = "planetGravity"
+    let description = "Surface gravity on a planet"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Planet name")
+        var planet: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "planet": arguments.planet,
+            "gravity": "9.8 m/s^2"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct PlanetAtmosphereTool: Tool {
+    let name = "planetAtmosphere"
+    let description = "Composition of a planet's atmosphere"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Planet name")
+        var planet: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "planet": arguments.planet,
+            "atmosphere": "Mostly nitrogen"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [PlanetDistanceTool(), PlanetGravityTool(), PlanetAtmosphereTool()],
+        instructions: "Use planet tools for astronomy questions"
+    )
+
+    try await session.respond(to: "How far is Mars from the sun?")
+    try await session.respond(to: "What is Mars's surface gravity?")
+    try await session.respond(to: "Describe Mars's atmosphere")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/PlantCareTools.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/PlantCareTools.swift
@@ -1,0 +1,77 @@
+//
+//  PlantCareTools.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/24/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct PlantWateringTool: Tool {
+    let name = "plantWatering"
+    let description = "How often to water a plant"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Plant type")
+        var plant: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "plant": arguments.plant,
+            "watering": "Weekly"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct PlantSunlightTool: Tool {
+    let name = "plantSunlight"
+    let description = "Sunlight requirements for a plant"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Plant type")
+        var plant: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "plant": arguments.plant,
+            "sunlight": "Partial shade"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct PlantSoilTool: Tool {
+    let name = "plantSoil"
+    let description = "Preferred soil type for a plant"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Plant type")
+        var plant: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "plant": arguments.plant,
+            "soil": "Well-draining"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [PlantWateringTool(), PlantSunlightTool(), PlantSoilTool()],
+        instructions: "Use plant tools to offer gardening tips"
+    )
+
+    try await session.respond(to: "How often should I water roses?")
+    try await session.respond(to: "How much sunlight do roses need?")
+    try await session.respond(to: "What soil is best for roses?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ProgrammingLanguageTools.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ProgrammingLanguageTools.swift
@@ -1,0 +1,77 @@
+//
+//  ProgrammingLanguageTools.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/24/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct ProgrammingLanguageYearTool: Tool {
+    let name = "languageYear"
+    let description = "Report the year a language was created"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Programming language")
+        var language: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "language": arguments.language,
+            "year": 1995
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct ProgrammingLanguageCreatorTool: Tool {
+    let name = "languageCreator"
+    let description = "Report who created a programming language"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Programming language")
+        var language: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "language": arguments.language,
+            "creator": "Famous Developer"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct ProgrammingLanguageParadigmTool: Tool {
+    let name = "languageParadigm"
+    let description = "State the primary paradigm of a language"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Programming language")
+        var language: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "language": arguments.language,
+            "paradigm": "Object-Oriented"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [ProgrammingLanguageYearTool(), ProgrammingLanguageCreatorTool(), ProgrammingLanguageParadigmTool()],
+        instructions: "Use language tools for programming trivia"
+    )
+
+    try await session.respond(to: "When was Swift created?")
+    try await session.respond(to: "Who created Swift?")
+    try await session.respond(to: "What paradigm is Swift primarily?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/RecipeInfoTools.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/RecipeInfoTools.swift
@@ -1,0 +1,77 @@
+//
+//  RecipeInfoTools.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/24/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct RecipeIngredientTool: Tool {
+    let name = "recipeIngredients"
+    let description = "List key ingredients for a recipe"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Recipe name")
+        var recipe: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "recipe": arguments.recipe,
+            "ingredients": "Flour, sugar, butter"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct RecipeStepsTool: Tool {
+    let name = "recipeSteps"
+    let description = "Describe steps to cook a recipe"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Recipe name")
+        var recipe: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "recipe": arguments.recipe,
+            "steps": "Mix, bake, serve"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct RecipeCookTimeTool: Tool {
+    let name = "recipeCookTime"
+    let description = "Estimate cook time for a recipe"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Recipe name")
+        var recipe: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "recipe": arguments.recipe,
+            "cookTime": "30 minutes"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [RecipeIngredientTool(), RecipeStepsTool(), RecipeCookTimeTool()],
+        instructions: "Use recipe tools for cooking advice"
+    )
+
+    try await session.respond(to: "What ingredients are in chocolate cake?")
+    try await session.respond(to: "How do I make chocolate cake?")
+    try await session.respond(to: "How long does chocolate cake take to bake?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/WorkoutInfoTools.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/WorkoutInfoTools.swift
@@ -1,0 +1,77 @@
+//
+//  WorkoutInfoTools.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/24/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct WorkoutCalorieTool: Tool {
+    let name = "workoutCalories"
+    let description = "Estimate calories burned in a workout"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Type of workout")
+        var workout: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "workout": arguments.workout,
+            "calories": 300
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct WorkoutDurationTool: Tool {
+    let name = "workoutDuration"
+    let description = "Typical duration for a workout"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Type of workout")
+        var workout: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "workout": arguments.workout,
+            "duration": "45 minutes"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+struct WorkoutEquipmentTool: Tool {
+    let name = "workoutEquipment"
+    let description = "Suggested equipment for a workout"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "Type of workout")
+        var workout: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let info = GeneratedContent(properties: [
+            "workout": arguments.workout,
+            "equipment": "Dumbbells"
+        ])
+        return ToolOutput(info)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [WorkoutCalorieTool(), WorkoutDurationTool(), WorkoutEquipmentTool()],
+        instructions: "Use workout tools for exercise questions"
+    )
+
+    try await session.respond(to: "How many calories does a run burn?")
+    try await session.respond(to: "How long should a run last?")
+    try await session.respond(to: "What equipment is good for running?")
+}

--- a/README.md
+++ b/README.md
@@ -124,3 +124,15 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 101. [`SafetyInstructions.swift`](Foundation-Models-Playgrounds/Playgrounds/SafetyInstructions.swift) – Provides strict safety instructions for the model.
 102. [`DataExtractor.swift`](Foundation-Models-Playgrounds/Playgrounds/DataExtractor.swift) – Extracts structured data from unstructured text.
 103. [`SentimentAnalyzer.swift`](Foundation-Models-Playgrounds/Playgrounds/SentimentAnalyzer.swift) – Determines the sentiment of provided text.
+
+### Miscellaneous Tool Demos
+104. [`CityInfoTools.swift`](Foundation-Models-Playgrounds/Playgrounds/CityInfoTools.swift) – Multi-tool sample for city population, area, and timezone.
+105. [`AnimalInfoTools.swift`](Foundation-Models-Playgrounds/Playgrounds/AnimalInfoTools.swift) – Multi-tool sample for animal facts, habitats, and diet.
+106. [`PlanetInfoTools.swift`](Foundation-Models-Playgrounds/Playgrounds/PlanetInfoTools.swift) – Multi-tool sample for planetary distances, gravity, and atmosphere.
+107. [`MovieInfoTools.swift`](Foundation-Models-Playgrounds/Playgrounds/MovieInfoTools.swift) – Multi-tool sample for movie rating, director, and cast.
+108. [`HistoricalEventTools.swift`](Foundation-Models-Playgrounds/Playgrounds/HistoricalEventTools.swift) – Multi-tool sample for event date, location, and key figure.
+109. [`PlantCareTools.swift`](Foundation-Models-Playgrounds/Playgrounds/PlantCareTools.swift) – Multi-tool sample for watering, sunlight, and soil needs.
+110. [`WorkoutInfoTools.swift`](Foundation-Models-Playgrounds/Playgrounds/WorkoutInfoTools.swift) – Multi-tool sample for calories, duration, and equipment.
+111. [`RecipeInfoTools.swift`](Foundation-Models-Playgrounds/Playgrounds/RecipeInfoTools.swift) – Multi-tool sample for ingredients, steps, and cook time.
+112. [`CarInfoTools.swift`](Foundation-Models-Playgrounds/Playgrounds/CarInfoTools.swift) – Multi-tool sample for price, fuel economy, and dealers.
+113. [`ProgrammingLanguageTools.swift`](Foundation-Models-Playgrounds/Playgrounds/ProgrammingLanguageTools.swift) – Multi-tool sample for creation year, creator, and paradigm.


### PR DESCRIPTION
## Summary
- add a new section in the README for miscellaneous examples
- create ten additional playgrounds, each using three unique tools

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684ba4ae467c8320a438108625562db8