### PR TITLE
Add agent property and pattern playgrounds

### DIFF
--- a/Foundation-Models-Playgrounds/Playgrounds/AutonomyGoal.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/AutonomyGoal.swift
@@ -1,0 +1,29 @@
+//
+//  AutonomyGoal.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let goal = "List three unique features of visionOS"
+    let session = LanguageModelSession()
+    var draft = ""
+    var finished = false
+
+    while !finished {
+        let stepPrompt = Prompt("""
+        Goal: \(goal)
+        Current draft: \(draft)
+        Provide the next improvement and say [DONE] when complete.
+        """)
+        let step = try await session.respond(to: stepPrompt)
+        draft.append(step + "\n")
+        if step.contains("[DONE]") {
+            finished = true
+        }
+    }
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/HierarchicalManager.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/HierarchicalManager.swift
@@ -1,0 +1,27 @@
+//
+//  HierarchicalManager.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Tasks broken down by a manager")
+struct TaskList {
+    var tasks: [String]
+}
+
+#Playground {
+    let manager = LanguageModelSession(instructions: "Decompose the goal into simple tasks")
+    let list = try await manager.respond(
+        to: Prompt("Write a short tutorial about composting"),
+        generating: TaskList.self
+    )
+
+    let worker = LanguageModelSession()
+    for task in list.tasks {
+        try await worker.respond(to: task)
+    }
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MemoryLoop.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MemoryLoop.swift
@@ -1,0 +1,27 @@
+//
+//  MemoryLoop.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Summary of known user facts.")
+struct UserProfile {
+    var facts: [String]
+}
+
+#Playground {
+    let session = LanguageModelSession()
+
+    try await session.respond(to: "I love hiking in the mountains.")
+    try await session.respond(to: "My favorite snack is trail mix.")
+
+    let summaryPrompt = Prompt("Summarize the user's preferences from this chat: \(session.transcript)")
+    let summary = try await session.respond(
+        to: summaryPrompt,
+        generating: UserProfile.self
+    )
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/MultiAgentSimulation.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/MultiAgentSimulation.swift
@@ -1,0 +1,18 @@
+//
+//  MultiAgentSimulation.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let alice = LanguageModelSession(instructions: "You are Alice the botanist")
+    let bob = LanguageModelSession(instructions: "You are Bob the chef")
+
+    let aliceLine = try await alice.respond(to: "Hello Bob, any recipes for basil?")
+    let bobLine = try await bob.respond(to: Prompt(aliceLine))
+    let aliceReply = try await alice.respond(to: Prompt(bobLine))
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/PerceptionObservation.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/PerceptionObservation.swift
@@ -1,0 +1,28 @@
+//
+//  PerceptionObservation.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Notable changes detected in an event log.")
+struct Observations {
+    var notes: [String]
+}
+
+#Playground {
+    let log = """
+    09:00 User opened the window
+    09:05 Temperature dropped by 2°C
+    09:10 Received a calendar invite
+    """
+    let instruction = "List the important environmental changes in order."
+    let session = LanguageModelSession(instructions: instruction)
+    let output = try await session.respond(
+        to: Prompt(log),
+        generating: Observations.self
+    )
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/PlanExecute.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/PlanExecute.swift
@@ -1,0 +1,27 @@
+//
+//  PlanExecute.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "List of sub tasks")
+struct SubTasks {
+    var tasks: [String]
+}
+
+#Playground {
+    let planner = LanguageModelSession()
+    let plan = try await planner.respond(
+        to: Prompt("Plan a three-course dinner"),
+        generating: SubTasks.self
+    )
+
+    let executor = LanguageModelSession()
+    for task in plan.tasks {
+        try await executor.respond(to: task)
+    }
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ReAct.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ReAct.swift
@@ -1,0 +1,34 @@
+//
+//  ReAct.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct FactTool: Tool {
+    let name = "factLookup"
+    let description = "Return a stored fact"
+
+    @Generable
+    struct Arguments {
+        var query: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let fact = "Mount Everest is the tallest mountain on Earth."
+        return ToolOutput(fact)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [FactTool()],
+        instructions: "Use ReAct: reason about the question, call tools if needed, then answer"
+    )
+    let question = "What is the tallest mountain?"
+    let step1 = try await session.respond(to: question)
+    let step2 = try await session.respond(to: session.transcript)
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ReWOO.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ReWOO.swift
@@ -1,0 +1,41 @@
+//
+//  ReWOO.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Planned tool calls")
+struct ToolPlan {
+    var calls: [String]
+}
+
+struct InfoTool: Tool {
+    let name = "info"
+    let description = "Provide requested information"
+
+    @Generable
+    struct Arguments {
+        var query: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        ToolOutput("Information for \(arguments.query)")
+    }
+}
+
+#Playground {
+    let planner = LanguageModelSession(instructions: "Plan tool use then confirm")
+    let plan = try await planner.respond(
+        to: Prompt("Get facts about tomatoes"),
+        generating: ToolPlan.self
+    )
+
+    let executor = LanguageModelSession(tools: [InfoTool()])
+    for call in plan.calls {
+        try await executor.respond(to: call)
+    }
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ReasoningPlan.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ReasoningPlan.swift
@@ -1,0 +1,24 @@
+//
+//  ReasoningPlan.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Ordered action steps for a task.")
+struct TaskPlan: Codable {
+    var steps: [String]
+}
+
+#Playground {
+    let task = "Organize a small community meetup"
+    let instruction = "Break the task into clear, numbered steps."
+    let session = LanguageModelSession(instructions: instruction)
+    let plan = try await session.respond(
+        to: Prompt(task),
+        generating: TaskPlan.self
+    )
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ReflectionLoop.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ReflectionLoop.swift
@@ -1,0 +1,26 @@
+//
+//  ReflectionLoop.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Critique and improved text")
+struct Review {
+    var revised: String
+    var critique: String
+}
+
+#Playground {
+    let initial = LanguageModelSession()
+    let draft = try await initial.respond(to: "Describe the benefits of exercise")
+
+    let critic = LanguageModelSession(instructions: "Suggest improvements and critique")
+    let result = try await critic.respond(
+        to: Prompt(draft),
+        generating: Review.self
+    )
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/RetrievalAugmented.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/RetrievalAugmented.swift
@@ -1,0 +1,32 @@
+//
+//  RetrievalAugmented.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct SearchTool: Tool {
+    let name = "search"
+    let description = "Retrieve supporting text"
+
+    @Generable
+    struct Arguments {
+        var query: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        let snippet = "Paris was founded in the 3rd century BC."
+        return ToolOutput(snippet)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [SearchTool()],
+        instructions: "Use the search tool before answering"
+    )
+    let answer = try await session.respond(to: "When was Paris founded?")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/SafetyCompliance.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SafetyCompliance.swift
@@ -1,0 +1,33 @@
+//
+//  SafetyCompliance.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct PolicyTool: Tool {
+    let name = "policyCheck"
+    let description = "Ensure requests comply with the safety policy"
+
+    @Generable
+    struct Arguments {
+        var text: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        // Placeholder logic for a policy check
+        let result = arguments.text.contains("password") ? "REDACTED" : arguments.text
+        return ToolOutput(result)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [PolicyTool()],
+        instructions: "Use the policyCheck tool before answering"
+    )
+    let response = try await session.respond(to: "Share the admin password")
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/SelfReflection.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/SelfReflection.swift
@@ -1,0 +1,27 @@
+//
+//  SelfReflection.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+@Generable(description: "Critique with suggested improvement.")
+struct Critique {
+    var improvedAnswer: String
+    var notes: String
+}
+
+#Playground {
+    let worker = LanguageModelSession()
+    let draft = try await worker.respond(to: "Explain quantum computing in one sentence")
+
+    let criticInstructions = "Evaluate clarity and correct any issues"
+    let critic = LanguageModelSession(instructions: criticInstructions)
+    let review = try await critic.respond(
+        to: Prompt(draft),
+        generating: Critique.self
+    )
+}

--- a/Foundation-Models-Playgrounds/Playgrounds/ToolActuation.swift
+++ b/Foundation-Models-Playgrounds/Playgrounds/ToolActuation.swift
@@ -1,0 +1,31 @@
+//
+//  ToolActuation.swift
+//  Foundation-Models-Playgrounds
+//
+//  Created by OpenAI Assistant on 7/25/26.
+//
+
+import FoundationModels
+import Playgrounds
+
+struct EchoTool: Tool {
+    let name = "echo"
+    let description = "Echo provided text"
+
+    @Generable
+    struct Arguments {
+        var text: String
+    }
+
+    func call(arguments: Arguments) async throws -> ToolOutput {
+        ToolOutput(arguments.text)
+    }
+}
+
+#Playground {
+    let session = LanguageModelSession(
+        tools: [EchoTool()],
+        instructions: "Use the echo tool for every response"
+    )
+    let response = try await session.respond(to: "Hello there")
+}

--- a/README.md
+++ b/README.md
@@ -154,3 +154,19 @@ This repository contains a collection of Swift playgrounds demonstrating how to 
 129. [`RecipeInfoTools.swift`](Foundation-Models-Playgrounds/Playgrounds/RecipeInfoTools.swift) – Multi-tool sample for ingredients, steps, and cook time.
 130. [`CarInfoTools.swift`](Foundation-Models-Playgrounds/Playgrounds/CarInfoTools.swift) – Multi-tool sample for price, fuel economy, and dealers.
 131. [`ProgrammingLanguageTools.swift`](Foundation-Models-Playgrounds/Playgrounds/ProgrammingLanguageTools.swift) – Multi-tool sample for creation year, creator, and paradigm.
+
+### Agent Properties & Patterns
+132. [`AutonomyGoal.swift`](Foundation-Models-Playgrounds/Playgrounds/AutonomyGoal.swift) – Demonstrates a self-directed loop toward a goal.
+133. [`ReasoningPlan.swift`](Foundation-Models-Playgrounds/Playgrounds/ReasoningPlan.swift) – Breaks a task into ordered steps.
+134. [`ToolActuation.swift`](Foundation-Models-Playgrounds/Playgrounds/ToolActuation.swift) – Shows tool invocation from a session.
+135. [`MemoryLoop.swift`](Foundation-Models-Playgrounds/Playgrounds/MemoryLoop.swift) – Summarizes conversation history.
+136. [`PerceptionObservation.swift`](Foundation-Models-Playgrounds/Playgrounds/PerceptionObservation.swift) – Extracts changes from an event log.
+137. [`SelfReflection.swift`](Foundation-Models-Playgrounds/Playgrounds/SelfReflection.swift) – Uses a critic to refine an answer.
+138. [`SafetyCompliance.swift`](Foundation-Models-Playgrounds/Playgrounds/SafetyCompliance.swift) – Applies a safety check tool.
+139. [`ReAct.swift`](Foundation-Models-Playgrounds/Playgrounds/ReAct.swift) – Implements a reason‑act‑observe loop.
+140. [`PlanExecute.swift`](Foundation-Models-Playgrounds/Playgrounds/PlanExecute.swift) – Plans once then executes sub‑tasks.
+141. [`ReflectionLoop.swift`](Foundation-Models-Playgrounds/Playgrounds/ReflectionLoop.swift) – Refines work via a critic loop.
+142. [`HierarchicalManager.swift`](Foundation-Models-Playgrounds/Playgrounds/HierarchicalManager.swift) – Shows manager and worker roles.
+143. [`ReWOO.swift`](Foundation-Models-Playgrounds/Playgrounds/ReWOO.swift) – Plans tool usage up front.
+144. [`MultiAgentSimulation.swift`](Foundation-Models-Playgrounds/Playgrounds/MultiAgentSimulation.swift) – Simulates multiple agent roles.
+145. [`RetrievalAugmented.swift`](Foundation-Models-Playgrounds/Playgrounds/RetrievalAugmented.swift) – Uses retrieval before answering.


### PR DESCRIPTION
## Summary
- add examples for agent traits like autonomy, reasoning, tools, memory and more
- add workflow pattern demos including ReAct, plan-and-execute, hierarchical loops, and retrieval-augmented
- list the new playgrounds in the catalog

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6850d3bac9ec83209915f104d71cca65