### PR TITLE
Update ContentView.swift

### DIFF
--- a/Foundation-Models-Playgrounds/ContentView.swift
+++ b/Foundation-Models-Playgrounds/ContentView.swift
@@ -12,7 +12,7 @@ struct ContentView: View {
         VStack {
             Text("Foundation Models Playgrounds")
                 .padding()
-                .font(.extraLargeTitle)
+                .font(.largeTitle)
             Text("View Playgrounds Folder for Code Examples")
                 .font(.largeTitle)
         }


### PR DESCRIPTION
its to fix the error
> 'extraLargeTitle' is unavailable in macos
'extraLargeTitle' has been explicitly marked unavailable here (SwiftUl.Font.extraLargeTitle)